### PR TITLE
Modification to the behavior of ModelData.attributes

### DIFF
--- a/egret/data/model_data.py
+++ b/egret/data/model_data.py
@@ -231,9 +231,6 @@ class ModelData(object):
         retdict = dict()
         retdict['names'] = list()
 
-        if not list(self.elements(element_type=element_type, **kwargs)):
-            return retdict
-
         for name, elem in self.elements(element_type=element_type, **kwargs):
             retdict['names'].append(name)
             for attrib, value in elem.items():

--- a/egret/data/model_data.py
+++ b/egret/data/model_data.py
@@ -229,11 +229,10 @@ class ModelData(object):
 
         """
         retdict = dict()
+        retdict['names'] = list()
 
         if not list(self.elements(element_type=element_type, **kwargs)):
             return retdict
-
-        retdict['names'] = list()
 
         for name, elem in self.elements(element_type=element_type, **kwargs):
             retdict['names'].append(name)

--- a/egret/data/model_data.py
+++ b/egret/data/model_data.py
@@ -228,6 +228,9 @@ class ModelData(object):
            * need a better error message when element_type is not found
 
         """
+        if element_type not in self.data['elements']:
+            return None
+
         retdict = dict()
         retdict['names'] = list()
 


### PR DESCRIPTION
This PR is for the unit commitment models, which right now expect the dictionary returned by ModelData.attributes() to have a 'names' key. As-is if there are no elements of element_type you get an empty dictionary--even if that element_type exists in the data dictionary but has no elements.

This change doesn't affect the OPF models--they still build/solve without complication (and identically). In the case of a particular element_type not being found, the for loop in ModelData.attributes() does nothing, so we get back a dictionary {'names' : [] }.