### PR TITLE
Fix for json keys being strings

### DIFF
--- a/egret/model_library/transmission/tx_utils.py
+++ b/egret/model_library/transmission/tx_utils.py
@@ -268,8 +268,10 @@ def _divide_by_baseMVA(element, attr_name, attr, baseMVA):
         elif 'data_type' in attr and attr['data_type'] == 'cost_curve':
             if attr['cost_curve_type'] == 'polynomial':
                 values_dict = attr['values']
+                new_values = dict()
                 for power, coeff in values_dict.items():
-                    values_dict[power] = coeff*baseMVA**power
+                    new_values[int(power)] = coeff*baseMVA**int(power)
+                attr['values'] = new_values
             elif attr['cost_curve_type'] == 'piecewise':
                 values_list_of_tuples = attr['values']
                 new_values = list()

--- a/egret/parsers/prescient_dat_parser.py
+++ b/egret/parsers/prescient_dat_parser.py
@@ -43,7 +43,7 @@ def create_model_data_dict(dat_file):
     elements = md_dict['elements']
     system = md_dict['system']
 
-    system['time_indices'] = list(params.TimePeriods)
+    system['time_indices'] = list(str(t) for t in params.TimePeriods)
     system['time_period_length_minutes'] = value(params.TimePeriodLengthMinutes)
 
     system['load_mismatch_cost'] = value(params.LoadMismatchPenalty)
@@ -77,13 +77,13 @@ def create_model_data_dict(dat_file):
                 'in_service': True,
                 'p_load':
                         {'data_type':'time_series',
-                            'values': { t : params.Demand[b,t] for t in params.TimePeriods }
+                            'values': { str(t) : params.Demand[b,t] for t in params.TimePeriods }
                         }
                }
         load_dict[b] = l_d
     elements['load'] = load_dict
 
-    reserve_dict = { t : value(params.ReserveRequirement[t]) for t in params.TimePeriods }
+    reserve_dict = { str(t) : value(params.ReserveRequirement[t]) for t in params.TimePeriods }
     system['spinning_reserve_requirement'] = { 'data_type':'time_series', 'values': reserve_dict }
 
     branch_dict = dict()
@@ -159,10 +159,10 @@ def create_model_data_dict(dat_file):
         g_d['in_service'] = True
         g_d['fuel'] = params.NondispatchableGeneratorType[g]
         g_d['p_min'] = { 'data_type':'time_series', 
-                            'values': { t : params.MinNondispatchablePower[g,t] for t in params.TimePeriods }
+                            'values': { str(t) : params.MinNondispatchablePower[g,t] for t in params.TimePeriods }
                        }
         g_d['p_max'] = { 'data_type':'time_series', 
-                            'values': { t : params.MaxNondispatchablePower[g,t] for t in params.TimePeriods }
+                            'values': { str(t) : params.MaxNondispatchablePower[g,t] for t in params.TimePeriods }
                        }
         ## NOTE: generators need unique names
         gen_dict[g+'_r'] = g_d


### PR DESCRIPTION
This is fix for issue #3.

Note that when the model_data dict gets dumped/loaded from json, dictionary keys are converted to strings. To keep things consistent, we need require that time_indices be strings, hence the update to the prescient_dat_parser.