### PR TITLE
Should only balance generators that are 'in service'

### DIFF
--- a/egret/model_library/transmission/tx_utils.py
+++ b/egret/model_library/transmission/tx_utils.py
@@ -171,6 +171,18 @@ def gens_by_bus(buses, gens):
     return gens_by_bus
 
 
+def gens_in_service_by_bus(buses, gens):
+    """
+    Return a dictionary of the generators attached to each bus
+    """
+    gens_by_bus = {k: list() for k in buses.keys()}
+    for gen_name, gen in gens.items():
+        if gen['in_service']:
+            gens_by_bus[gen['bus']].append(gen_name)
+
+    return gens_by_bus
+
+
 ## attributes which are scaled for power flow models
 scaled_attributes = {
                          ('element_type','generator'): [

--- a/egret/models/acopf.py
+++ b/egret/models/acopf.py
@@ -42,7 +42,7 @@ def create_psv_acopf_model(model_data):
 
     inlet_branches_by_bus, outlet_branches_by_bus = \
         tx_utils.inlet_outlet_branches_by_bus(branches, buses)
-    gens_by_bus = tx_utils.gens_by_bus(buses, gens)
+    gens_by_bus = tx_utils.gens_in_service_by_bus(buses, gens)
 
     model = pe.ConcreteModel()
 
@@ -223,7 +223,7 @@ def create_rsv_acopf_model(model_data):
 
     inlet_branches_by_bus, outlet_branches_by_bus = \
         tx_utils.inlet_outlet_branches_by_bus(branches, buses)
-    gens_by_bus = tx_utils.gens_by_bus(buses, gens)
+    gens_by_bus = tx_utils.gens_in_service_by_bus(buses, gens)
 
     model = pe.ConcreteModel()
 
@@ -405,7 +405,7 @@ def create_riv_acopf_model(model_data):
 
     inlet_branches_by_bus, outlet_branches_by_bus = \
         tx_utils.inlet_outlet_branches_by_bus(branches, buses)
-    gens_by_bus = tx_utils.gens_by_bus(buses, gens)
+    gens_by_bus = tx_utils.gens_in_service_by_bus(buses, gens)
 
     model = pe.ConcreteModel()
 

--- a/egret/models/dcopf.py
+++ b/egret/models/dcopf.py
@@ -41,7 +41,7 @@ def create_btheta_dcopf_model(model_data):
 
     inlet_branches_by_bus, outlet_branches_by_bus = \
         tx_utils.inlet_outlet_branches_by_bus(branches, buses)
-    gens_by_bus = tx_utils.gens_by_bus(buses, gens)
+    gens_by_bus = tx_utils.gens_in_service_by_bus(buses, gens)
 
     model = pe.ConcreteModel()
 

--- a/egret/models/economic_dispatch.py
+++ b/egret/models/economic_dispatch.py
@@ -41,7 +41,7 @@ def create_economic_dispatch_approx_model(model_data):
 
     inlet_branches_by_bus, outlet_branches_by_bus = \
         tx_utils.inlet_outlet_branches_by_bus(branches, buses)
-    gens_by_bus = tx_utils.gens_by_bus(buses, gens)
+    gens_by_bus = tx_utils.gens_in_service_by_bus(buses, gens)
 
     model = pe.ConcreteModel()
 


### PR DESCRIPTION
New function in tx_utils that returns gens_in_service_by_bus. Created this function instead of requiring gen_attrs to be passed into the balancing constraints.