### PR TITLE
Adding functionality to ignore out of service elements

### DIFF
--- a/egret/data/model_data.py
+++ b/egret/data/model_data.py
@@ -253,6 +253,18 @@ class ModelData(object):
         """
         return ModelData(cp.deepcopy(self.data))
 
+    def clone_in_service(self):
+        """
+        Create a copy of this ModelData object using a deep copy on the underlying dictionary,
+        only returning the elements for which the in_service flag is not set to False
+
+        Returns
+        -------
+            ModelData
+        """
+        return ModelData(_copy_only_in_service(self.data))
+
+
     def clone_at_timestamp(self, timestamp):
         """
         Creae a copy of the ModelData object using values from a single timestamp.
@@ -307,3 +319,23 @@ def map_items(func, d):
 
 def zip_items(dict_lb, dict_ub):
     return {k: (dict_lb[k], dict_ub[k]) for k in dict_lb.keys()}
+
+def _copy_only_in_service(data_dict):
+    new_dd = dict()
+    for key, value in data_dict.items():
+        if key == 'elements':
+            ## value is the elements dictionary
+            new_dd[key] = dict()
+            new_elements = new_dd[key]
+            for elements_name, elements in value.items():
+                new_elements[elements_name] = dict()
+                new_element_dict = new_elements[elements_name]
+                for element_name, element in elements.items():
+                    if 'in_service' in element and (not element['in_service']):
+                        continue
+                    else:
+                        new_element_dict[element_name] = cp.deepcopy(element)
+        else:
+            new_dd[key] = cp.deepcopy(value)
+    return new_dd
+

--- a/egret/model_library/transmission/tx_utils.py
+++ b/egret/model_library/transmission/tx_utils.py
@@ -257,12 +257,12 @@ scaled_attributes = {
                    }
 
 
-def scale_ModelData_to_pu(model_data):
-    return _convert_modeldata_pu(model_data, _divide_by_baseMVA)
+def scale_ModelData_to_pu(model_data, inplace=False):
+    return _convert_modeldata_pu(model_data, _divide_by_baseMVA, inplace)
 
 
-def unscale_ModelData_to_pu(model_data):
-    return _convert_modeldata_pu(model_data, _multiply_by_baseMVA)
+def unscale_ModelData_to_pu(model_data, inplace=False):
+    return _convert_modeldata_pu(model_data, _multiply_by_baseMVA, inplace)
 
 
 def _multiply_by_baseMVA(element, attr_name, attr, baseMVA):
@@ -297,9 +297,12 @@ def _divide_by_baseMVA(element, attr_name, attr, baseMVA):
 ## NOTE: ideally this would be done in the definitions of
 ##       these constraints. Futher, it is not obvious that
 ##       the baseMVA provides the best scaling
-def _convert_modeldata_pu(model_data, transform_func):
+def _convert_modeldata_pu(model_data, transform_func, inplace):
 
-    md = model_data.clone()
+    if inplace:
+        md = model_data
+    else:
+        md = model_data.clone()
     baseMVA = float(md.data['system']['baseMVA'])
 
     for (attr_type, element_type), attributes in scaled_attributes.items():
@@ -319,5 +322,8 @@ def _convert_modeldata_pu(model_data, transform_func):
                     if attr_name in attributes:
                         transform_func(element, attr_name, attr, baseMVA)
 
-    return md
+    if inplace:
+        return
+    else:
+        return md
 


### PR DESCRIPTION
Adds a method to ModelData, clone_in_service, to only clone elements which have non-False in_service flags. Elements without in_service flag are cloned.