### PR TITLE
Reactivating and updating dependencies in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools_kwargs = {
     'install_requires': [],
     'scripts': [],
     'include_package_data': True,
-#    'install_requires' : ['networkx', 'scipy', 'numpy']
+    'install_requires' : ['pyomo>=5.6', 'numpy', 'pytest']
 }
 
 setup(name=DISTNAME,


### PR DESCRIPTION
To maximize chances of a smooth install, I reactivated the dependency list in setup.py and modified it to include: 

- Pyomo >=5.6
- numpy (unsure if we need a specific version dependency)
- pytest

The last item might be mildly controversial. I decided to include this dependency so that users can quickly run some basic regression tests, making it easy to kick the tires on the new install.