### PR TITLE
Making _add_egret_power_flow consistent with the modified storage model

### DIFF
--- a/egret/model_library/unit_commitment/power_balance.py
+++ b/egret/model_library/unit_commitment/power_balance.py
@@ -190,7 +190,7 @@ def _get_pg_expr_rule(t):
         # bus b, time t (S)
         if m.storage_services:
             return sum(m.PowerGenerated[g, t] for g in m.ThermalGeneratorsAtBus[b]) \
-                + sum(m.PowerOutputStorage[s, t]*m.OutputEfficiencyEnergy[s] for s in m.StorageAtBus[b])\
+                + sum(m.PowerOutputStorage[s, t] for s in m.StorageAtBus[b])\
                 - sum(m.PowerInputStorage[s, t] for s in m.StorageAtBus[b])\
                 + sum(m.NondispatchablePowerUsed[g, t] for g in m.NondispatchableGeneratorsAtBus[b]) \
                 + m.LoadGenerateMismatch[b,t]


### PR DESCRIPTION
PowerOutputStorage was modified in the storage model to be the "grid side" output of the storage. This is reflected in the `power_balance` version of power flow (see line 308) but not in the _add_egret_power_flow version, likely due to a manual merge error.