### PR TITLE
Fix for model_data scaling

### DIFF
--- a/egret/model_library/transmission/tx_utils.py
+++ b/egret/model_library/transmission/tx_utils.py
@@ -231,7 +231,7 @@ scaled_attributes = {
                                                           'pg',
                                                           'qg',
                                                           'rg',
-                                                          'headroom'
+                                                          'headroom',
                                                           'reg_up_supplied',
                                                           'reg_down_supplied',
                                                           'spin_supplied',


### PR DESCRIPTION
A missing comma in the master dictionary was causing a few thermal generator attributes not to be scaled upon output.