### PR TITLE
Enforced sorting of stack graph components

### DIFF
--- a/egret/viz/generate_graphs.py
+++ b/egret/viz/generate_graphs.py
@@ -63,6 +63,15 @@ BUILT_IN_FUEL_CODES = [
     ('Hydro', 'H'),
     ('Sync_Cond', 'SC'),
     ('Biomass', 'B'),
+    # To accomodate data that uses the codes directly
+    ('O', 'O'),
+    ('C', 'C'),
+    ('G', 'G'),
+    ('S', 'S'),
+    ('W', 'W'),
+    ('N', 'N'),
+    ('SC', 'SC'),
+    ('B', 'B'),
 ]
 
 
@@ -457,65 +466,68 @@ def main():
 
     current_dir = os.path.dirname(os.path.abspath(__file__))
 
-    ## Test using unit commitment unit test case(s)
-    # from egret.data.model_data import ModelData
+    TEST_WITH_RTS_GMLC = True
 
-    # test_cases = [os.path.join(current_dir, '..', 'models', 'tests', 'uc_test_instances', 'test_case_{}.json'.format(i)) for i in range(1, 6)]
+    if TEST_WITH_RTS_GMLC:
+        # Test using RTS-GMLC case, if available
+        from egret.parsers.rts_gmlc_parser import create_ModelData
 
-    # for test_case in test_cases:   
-    #     with open(test_case, 'r') as f:
-    #         md_dict = json.load(f)
-    #     md = ModelData(md_dict)
+        rts_gmlc_dir = os.path.join(current_dir, '..', '..', '..', 'RTS-GMLC')
+        begin_time = "2020-07-01"
+        end_time = "2020-07-02"
 
-    #     solved_md = solve_unit_commitment(md,
-    #                     'cbc',
-    #                     mipgap = 0.001,
-    #                     timelimit = None,
-    #                     solver_tee = True,
-    #                     symbolic_solver_labels = False,
-    #                     options = None,
-    #                     uc_model_generator=create_tight_unit_commitment_model,
-    #                     relaxed=False,
-    #                     return_model=False)
+        md = create_ModelData(
+            rts_gmlc_dir, begin_time, end_time, 
+            # simulation="DAY_AHEAD", t0_state = None,
+            )
+        
+        solved_md = solve_unit_commitment(md,
+                        'gurobi',
+                        mipgap = 0.001,
+                        timelimit = None,
+                        solver_tee = True,
+                        symbolic_solver_labels = False,
+                        options = None,
+                        uc_model_generator=create_tight_unit_commitment_model,
+                        relaxed=False,
+                        return_model=False)
 
-    #     fig, ax = generate_stack_graph(
-    #         solved_md, 
-    #         title=repr(test_case),
-    #         show_individual_components=True,
-    #         plot_individual_generators=False,
-    #     )
-    
-    ## Test using RTS-GMLC case
-    from egret.parsers.rts_gmlc_parser import create_ModelData
-
-    rts_gmlc_dir = os.path.join(current_dir, '..', '..', '..', 'RTS-GMLC')
-    begin_time = "2020-07-01"
-    end_time = "2020-07-02"
-
-    md = create_ModelData(
-        rts_gmlc_dir, begin_time, end_time, 
-        # simulation="DAY_AHEAD", t0_state = None,
+        fig, ax = generate_stack_graph(
+            solved_md, 
+            title=begin_time,
+            show_individual_components=False,
+            plot_individual_generators=False,
+            x_tick_frequency=4,
         )
+    else:
+        ## Test using built-in unit commitment unit test case(s)
+        from egret.data.model_data import ModelData
+
+        test_cases = [os.path.join(current_dir, '..', 'models', 'tests', 'uc_test_instances', 'test_case_{}.json'.format(i)) for i in range(1, 6)]
+
+        for test_case in test_cases:   
+            with open(test_case, 'r') as f:
+                md_dict = json.load(f)
+            md = ModelData(md_dict)
+
+            solved_md = solve_unit_commitment(md,
+                            'cbc',
+                            mipgap = 0.001,
+                            timelimit = None,
+                            solver_tee = True,
+                            symbolic_solver_labels = False,
+                            options = None,
+                            uc_model_generator=create_tight_unit_commitment_model,
+                            relaxed=False,
+                            return_model=False)
+
+            fig, ax = generate_stack_graph(
+                solved_md, 
+                title=repr(test_case),
+                show_individual_components=False,
+                plot_individual_generators=False,
+            )
     
-    solved_md = solve_unit_commitment(md,
-                    'gurobi',
-                    mipgap = 0.001,
-                    timelimit = None,
-                    solver_tee = True,
-                    symbolic_solver_labels = False,
-                    options = None,
-                    uc_model_generator=create_tight_unit_commitment_model,
-                    relaxed=False,
-                    return_model=False)
-
-    fig, ax = generate_stack_graph(
-        solved_md, 
-        title=begin_time,
-        show_individual_components=False,
-        plot_individual_generators=False,
-        x_tick_frequency=4,
-    )
-
     plt.show()
 
 

--- a/egret/viz/generate_graphs.py
+++ b/egret/viz/generate_graphs.py
@@ -408,6 +408,7 @@ def generate_stack_graph(egret_model_data, bar_width=0.9,
         is_quickstart = gen_data.get('quickstart_capable', False)
 
         if is_quickstart:
+            commitment = attribute_to_array(gen_data['commitment'])
             p_max = gen_data['p_max']
             startup_capacity = gen_data['startup_capacity']
             quickstart_capacity = min(p_max, startup_capacity)

--- a/egret/viz/generate_graphs.py
+++ b/egret/viz/generate_graphs.py
@@ -375,14 +375,12 @@ def generate_stack_graph(egret_model_data, bar_width=0.9,
     generators_dict = egret_model_data.data['elements']['generator']
     reserves_by_hour = np.zeros(len(indices))
 
-    for gen, gen_data in generators_dict.items():
+    for _, gen_data in generators_dict.items():
         is_quickstart = gen_data.get('quickstart_capable', False)
 
-        if not is_quickstart:
-            p_max = attribute_to_array(gen_data['p_max'])
-            pg = attribute_to_array(gen_data['pg'])
-
-            reserves_available = np.maximum(p_max - pg, 0)
+        if gen_data['generator_type'] == 'thermal' and not is_quickstart:
+            headroom = attribute_to_array(gen_data['headroom'])
+            reserves_available = np.maximum(headroom, 0)
 
             reserves_by_hour += reserves_available
     
@@ -401,14 +399,12 @@ def generate_stack_graph(egret_model_data, bar_width=0.9,
     # Add quick-start capacity, if applicable.
     total_quickstart_capacity_by_hour = np.zeros(len(indices))
 
-    for gen, gen_data in generators_dict.items():
+    for _, gen_data in generators_dict.items():
         is_quickstart = gen_data.get('quickstart_capable', False)
 
         if is_quickstart:
-            p_max = attribute_to_array(gen_data['p_max'])
-            pg = attribute_to_array(gen_data['pg'])
-
-            quickstart_capacity_available = np.maximum(p_max - pg, 0)
+            headroom = attribute_to_array(gen_data['headroom'])
+            quickstart_capacity_available = np.maximum(headroom, 0)
 
             total_quickstart_capacity_by_hour += quickstart_capacity_available
     
@@ -423,7 +419,7 @@ def generate_stack_graph(egret_model_data, bar_width=0.9,
     # Add renewable curtailment.
     total_renewable_curtailment_by_hour = np.zeros(len(indices))
 
-    for gen, gen_data in generators_dict.items():
+    for _, gen_data in generators_dict.items():
         generator_type = gen_data['generator_type']
 
         if generator_type == 'renewable':


### PR DESCRIPTION
This PR makes changes to the stack graph generation module.

## Additions
* Stack graph generation groups are now sorted deterministically according to module definitions. Previously, the order was determined by dictionary insertion order which was likely related to generator names. Now, the groups are sorted in a predetermined order before each stack is constructed. This order is (from bottom to top):
1) Nuclear
1) Coal
1) Hydro
1) Gas/NG
1) Oil
1) Synchronous Condenser
1) Wind
1) Solar/PV
1) Biomass
1) Geothermal
1) Battery
  * The remaining components of the stacks such as renewable curtailment and load shed will remain ordered as previously. 
  * This change also applies when individual generators are broken out discretely within each generation type grouping.

## Resolved Issues
* An issue where certain generator/fuel types could not be recognized by the stack graph generation functions resulting in KeyError exceptions. The code relies on the "fuel" field of generator objects to determine how to categorize them for the graphs. 
  * "Gas" is now recognized as "NG"
  * "PV" is now recognized as "Solar"
* An issue where thermal generators that were not producing power during the simulation time period would still contribute to the stack graph.
  * For example, while generators of type "Oil" were among the generator elements in the model, none of them are producing power. Despite having no contributions to the stack graph, a legend entry for "Oil" would have previously appeared. Now, generation types that do not contribute to the stack graphs will no longer appear in the legend.

## Known issues
* Using string matching to categorize generation types is clunky because, to my knowledge, there is no "enumeration" of generator/fuel types. For example, one dataset used "NG" for natural gas while another used "Gas" despite each generally referring to the same thing. Because this module relies on dictionaries to categorize generators, it is sensitive to the input data. A failsafe could be to categorize every generator type that doesn't match the existing "lookup" dictionaries as "Unknown" which could at least handle KeyErrors.