### PR TITLE
Lazy PTDF Enhancements

### DIFF
--- a/egret/common/lazy_ptdf_utils.py
+++ b/egret/common/lazy_ptdf_utils.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from enum import Enum
 
+
 class LazyPTDFTerminationCondition(Enum):
     NORMAL = 1
     ITERATION_LIMIT = 2
@@ -68,32 +69,74 @@ def check_and_scale_ptdf_options(ptdf_options, baseMVA):
     if abs_ptdf_tol < 1e-12:
         print("WARNING: abs_ptdf_tol={0}, which is low enough it may cause numerical issues in the solver. Consider rasing abs_ptdf_tol.".format(abs_ptdf_tol*baseMVA))
 
-## violation checker
-def check_violations(m, PTDF, max_viol_add):
+## to hold the indicies of the violations
+## in the model or block
+def add_monitored_branch_tracker(mb):
+    mb._lt_idx_monitored = list()
+    mb._gt_idx_monitored = list()
 
-    NWV = np.array([pe.value(m.p_nw[b]) for b in PTDF.bus_iterator()])
+## violation checker
+def check_violations(mb, md, PTDF, max_viol_add, time=None):
+
+    NWV = np.array([pe.value(mb.p_nw[b]) for b in PTDF.bus_iterator()])
     NWV += PTDF.phi_adjust_array
 
     PFV  = np.dot(PTDF.PTDFM, NWV)
     PFV += PTDF.phase_shift_array
 
-    ## calculate the violations
-    gt_viol = np.nonzero(np.greater(PFV, PTDF.enforced_branch_limits))[0]
-    lt_viol = np.nonzero(np.less(PFV, -PTDF.enforced_branch_limits))[0]
+    ## calculate the negative of the violations (for easy sorting)
+    gt_viol_array = PTDF.enforced_branch_limits - PFV
+    lt_viol_array = PFV + PTDF.enforced_branch_limits
 
-    ## these will hold the violations we add at this iteration
-    gt_viol_lazy = gt_viol
-    lt_viol_lazy = lt_viol
+    gt_viol = np.nonzero(gt_viol_array < 0)[0]
+    lt_viol = np.nonzero(lt_viol_array < 0)[0]
+
+    ## these will hold the violations 
+    ## we found this iteration
+    gt_viol = frozenset(gt_viol)
+    lt_viol = frozenset(lt_viol)
+
+    ## get the lines we're monitoring
+    gt_idx_monitored = mb._gt_idx_monitored
+    lt_idx_monitored = mb._lt_idx_monitored
+
+    ## get the lines for which we've found a violation that's
+    ## in the model
+    gt_viol_in_mb = gt_viol.intersection(gt_idx_monitored)
+    lt_viol_in_mb = lt_viol.intersection(lt_idx_monitored)
+
+    ## print a warning for these lines
+    ## check if the found violations are in the model and print warning
+    baseMVA = md.data['system']['baseMVA']
+    for i in lt_viol_in_mb:
+        bn = PTDF.branches_keys[i]
+        thermal_limit = PTDF.branch_limits_array[i]
+        print(_generate_flow_viol_warning('LB', mb, bn, PFV[i], -thermal_limit, baseMVA, time))
+
+    for i in gt_viol_in_mb:
+        bn = PTDF.branches_keys[i]
+        thermal_limit = PTDF.branch_limits_array[i]
+        print(_generate_flow_viol_warning('UB', mb, bn, PFV[i], thermal_limit, baseMVA, time))
+
+    ## *t_viol_lazy will hold the lines we're adding
+    ## this iteration -- don't want to add lines
+    ## that are already in the monitored set
+    gt_viol_lazy = gt_viol.difference(gt_idx_monitored)
+    lt_viol_lazy = lt_viol.difference(lt_idx_monitored)
 
     ## limit the number of lines we add in one iteration
     ## if we have too many violations, just take those largest
     ## in absolute value in either direction
     if len(gt_viol_lazy)+len(lt_viol_lazy) > max_viol_add:
 
-        ## these store the negative of the violations for
-        ## sorting below
-        gt_viol_array = PTDF.branch_limits_array - PFV
-        lt_viol_array = PFV + PTDF.branch_limits_array
+        ## for those in the monitored set, assume they're feasible for
+        ## the purposes of sorting the worst violations, which means
+        ## resetting the values for these lines as computed above
+
+        ## use what most solvers consider +infty
+        LARGE_CONST = 1e+100
+        gt_viol_array[gt_idx_monitored] = LARGE_CONST
+        lt_viol_array[lt_idx_monitored] = LARGE_CONST
 
         ## give the order of the first max_viol_add violations
         measured_gt_viol = np.argpartition(gt_viol_array, range(max_viol_add))
@@ -101,8 +144,8 @@ def check_violations(m, PTDF, max_viol_add):
 
         measured_gt_viol_pos = 0
         measured_lt_viol_pos = 0
-        gt_viol_lazy = list()
-        lt_viol_lazy = list()
+        gt_viol_lazy = set()
+        lt_viol_lazy = set()
         for _ in range(max_viol_add):
             gt_v = gt_viol_array[measured_gt_viol[measured_gt_viol_pos]]
             lt_v = lt_viol_array[measured_lt_viol[measured_lt_viol_pos]]
@@ -113,15 +156,16 @@ def check_violations(m, PTDF, max_viol_add):
             if gt_v > 0 and lt_v > 0:
                 break
             elif gt_v < lt_v:
-                gt_viol_lazy.append(measured_gt_viol[measured_gt_viol_pos])
+                gt_viol_lazy.add(measured_gt_viol[measured_gt_viol_pos])
                 measured_gt_viol_pos += 1
             else:
-                lt_viol_lazy.append(measured_lt_viol[measured_lt_viol_pos])
+                lt_viol_lazy.add(measured_lt_viol[measured_lt_viol_pos])
                 measured_lt_viol_pos += 1
 
     viol_num = len(gt_viol)+len(lt_viol)
+    monitored_viol_num = len(lt_viol_in_mb)+len(gt_viol_in_mb)
 
-    return PFV, viol_num, (gt_viol, lt_viol, gt_viol_lazy, lt_viol_lazy)
+    return PFV, viol_num, monitored_viol_num, gt_viol_lazy, lt_viol_lazy
     
 def _generate_flow_viol_warning(sense, mb, bn, flow, limit, baseMVA, time):
     ret_str = "WARNING: line {0} ({1}) is in the  monitored set".format(bn, sense)
@@ -139,15 +183,15 @@ def _generate_flow_monitor_message(sense, bn, flow, limit, baseMVA, time):
     return ret_str
 
 ## violation adder
-def add_violations(viols_tup, PFV, mb, md, solver, ptdf_options,
+def add_violations(gt_viol_lazy, lt_viol_lazy, PFV, mb, md, solver, ptdf_options,
                     PTDF, time=None):
 
     model = mb.model()
 
-    persistent_solver = isinstance(solver, PersistentSolver)
     baseMVA = md.data['system']['baseMVA']
 
-    gt_viol, lt_viol, gt_viol_lazy, lt_viol_lazy = viols_tup
+    persistent_solver = isinstance(solver, PersistentSolver)
+
     ## static information between runs
     rel_ptdf_tol = ptdf_options['rel_ptdf_tol']
     abs_ptdf_tol = ptdf_options['abs_ptdf_tol']
@@ -161,36 +205,25 @@ def add_violations(viols_tup, PFV, mb, md, solver, ptdf_options,
                 mb.pf[bn] = expr
             yield i, bn
 
-    lt_viol_in_constr = 0
+    constr = mb.ineq_pf_branch_thermal_lb
+    lt_viol_in_mb = mb._lt_idx_monitored
     for i, bn in _iter_over_viol_set(lt_viol_lazy):
-        constr = mb.ineq_pf_branch_thermal_lb
         thermal_limit = PTDF.branch_limits_array[i]
-        if bn in constr and i in lt_viol:
-            print(_generate_flow_viol_warning('LB', mb, bn, PFV[i], -thermal_limit, baseMVA, time))
-            lt_viol_in_constr += 1
-        elif bn not in constr: 
-            print(_generate_flow_monitor_message('LB', bn, PFV[i], -thermal_limit, baseMVA, time))
-            constr[bn] = (-thermal_limit, mb.pf[bn], None)
-            if persistent_solver:
-                solver.add_constraint(constr[bn])
+        print(_generate_flow_monitor_message('LB', bn, PFV[i], -thermal_limit, baseMVA, time))
+        constr[bn] = (-thermal_limit, mb.pf[bn], None)
+        lt_viol_in_mb.append(i)
+        if persistent_solver:
+            solver.add_constraint(constr[bn])
 
-    gt_viol_in_constr = 0
+    constr = mb.ineq_pf_branch_thermal_ub
+    gt_viol_in_mb = mb._gt_idx_monitored
     for i, bn in _iter_over_viol_set(gt_viol_lazy):
-        constr = mb.ineq_pf_branch_thermal_ub
         thermal_limit = PTDF.branch_limits_array[i]
-        if bn in constr and i in gt_viol:
-            print(_generate_flow_viol_warning('UB', mb, bn, PFV[i], thermal_limit, baseMVA, time))
-            gt_viol_in_constr += 1
-        elif bn not in constr:
-            print(_generate_flow_monitor_message('UB', bn, PFV[i], thermal_limit, baseMVA, time))
-            constr[bn] = (None, mb.pf[bn], thermal_limit)
-            if persistent_solver:
-                solver.add_constraint(constr[bn])
-
-    all_viol_in_mb = (len(lt_viol) > 0 or len(gt_viol) > 0) and \
-                    (len(lt_viol) == lt_viol_in_constr) \
-                      and (len(gt_viol) == gt_viol_in_constr)
-    return all_viol_in_mb
+        print(_generate_flow_monitor_message('UB', bn, PFV[i], thermal_limit, baseMVA, time))
+        constr[bn] = (None, mb.pf[bn], thermal_limit)
+        gt_viol_in_mb.append(i)
+        if persistent_solver:
+            solver.add_constraint(constr[bn])
 
 
 def _binary_var_generator(instance):

--- a/egret/common/lazy_ptdf_utils.py
+++ b/egret/common/lazy_ptdf_utils.py
@@ -30,8 +30,6 @@ def populate_default_ptdf_options(ptdf_options):
         ptdf_options['abs_flow_tol'] = 1.e-3
     if 'rel_flow_tol' not in ptdf_options:
         ptdf_options['rel_flow_tol'] = 1.e-5
-    if 'lazy_rel_flow_tol' not in ptdf_options:
-        ptdf_options['lazy_rel_flow_tol'] = -0.05
     if 'iteration_limit' not in ptdf_options:
         ptdf_options['iteration_limit'] = 100000
     if 'lp_iteration_limit' not in ptdf_options:
@@ -56,16 +54,11 @@ def check_and_scale_ptdf_options(ptdf_options, baseMVA):
     rel_ptdf_tol = ptdf_options['rel_ptdf_tol']
     abs_ptdf_tol = ptdf_options['abs_ptdf_tol']
 
-    lazy_rel_flow_tol = ptdf_options['lazy_rel_flow_tol']
-
     max_violations_per_iteration = ptdf_options['max_violations_per_iteration']
 
     if max_violations_per_iteration < 1 or (not isinstance(max_violations_per_iteration, int)):
         raise Exception("max_violations_per_iteration must be an integer least 1, max_violations_per_iteration={}".format(max_violations_per_iteration))
 
-    if abs_flow_tol < lazy_rel_flow_tol:
-        raise Exception("abs_flow_tol (when scaled by baseMVA) cannot be less than lazy_flow_tol"
-                        " abs_flow_tol={0}, lazy_flow_tol={1}, baseMVA={2}".format(abs_flow_tol*baseMVA, lazy_flow_tol, baseMVA))
     if abs_flow_tol < 1e-6:
         print("WARNING: abs_flow_tol={0}, which is below the numeric threshold of most solvers.".format(abs_flow_tol*baseMVA))
     if abs_flow_tol < rel_ptdf_tol*10:

--- a/egret/common/solver_interface.py
+++ b/egret/common/solver_interface.py
@@ -74,7 +74,8 @@ def _solve_model(model,
                  solver_tee = True,
                  symbolic_solver_labels = False,
                  options = None,
-                 return_solver = False):
+                 return_solver = False,
+                 vars_to_load = None):
     '''
     Create and solve an Egret power system optimization model
 
@@ -97,6 +98,9 @@ def _solve_model(model,
         Other options to pass into the solver. Default is dict().
     return_solver : bool (optional)
         Returns the solver object
+    vars_to_load : list (optional)
+        When supplied, and the solver is persistent, this will just load
+        pyomo variables specificed
 
     Returns
     -------
@@ -139,11 +143,12 @@ def _solve_model(model,
         raise Exception('Problem encountered during solve, termination_condition {}'.format(results.solver.termination_condition))
 
     if isinstance(solver, PersistentSolver):
-        solver.load_vars()
-        if hasattr(model, "dual"):
-            solver.load_duals()
-        if hasattr(model, "slack"):
-            solver.load_slacks()
+        solver.load_vars(vars_to_load)
+        if vars_to_load is None:
+            if hasattr(model, "dual"):
+                solver.load_duals()
+            if hasattr(model, "slack"):
+                solver.load_slacks()
     else:
         model.solutions.load_from(results)
 

--- a/egret/data/data_utils.py
+++ b/egret/data/data_utils.py
@@ -171,6 +171,12 @@ class PTDFMatrix(object):
     def get_bus_phi_adj(self, bus_name):
         return self.phi_adjust_array[self._busname_to_index_map[bus_name]]
 
+    def get_branch_phi_adj(self, branch_name):
+        row_idx = self._branchname_to_index_map[branch_name]
+        ## get the row slice
+        PTDF_row = self.PTDFM[row_idx]
+        return np.dot(PTDF_row, self.phi_adjust_array)
+
     def bus_iterator(self):
         yield from self.buses_keys
 

--- a/egret/data/data_utils.py
+++ b/egret/data/data_utils.py
@@ -263,3 +263,9 @@ class PTDFLossesMatrix(PTDFMatrix):
 
     def get_bus_phi_losses_adj(self, bus_name):
         return self.phi_losses_adjust_array[self._busname_to_index_map[bus_name]]
+
+    def get_branch_phi_losses_adj(self, branch_name):
+        row_idx = self._branchname_to_index_map[branch_name]
+        ## get the row slice
+        losses_row = self.LDF[row_idx]
+        return np.dot(losses_row, self.phi_losses_adjust_array)

--- a/egret/data/data_utils.py
+++ b/egret/data/data_utils.py
@@ -107,7 +107,6 @@ class PTDFMatrix(object):
         self._calculate()
 
         ## for lazy PTDF
-        self.lazy_branch_limits = None
         self.enforced_branch_limits = None
 
     def _calculate(self):

--- a/egret/model_library/transmission/branch.py
+++ b/egret/model_library/transmission/branch.py
@@ -380,9 +380,6 @@ def get_power_flow_expr_ptdf_approx(model, branch_name, PTDF, rel_ptdf_tol=None,
 
     max_coef = PTDF.get_branch_ptdf_abs_max(branch_name)
 
-    ## This case is weird, but could happen, causing divison by 0 below
-    if max_coef == 0:
-        return const
     ptdf_tol = max(abs_ptdf_tol, rel_ptdf_tol*max_coef) 
     ## NOTE: It would be easy to hold on to the 'ptdf' dictionary here,
     ##       if we wanted to
@@ -434,9 +431,6 @@ def get_branch_loss_expr_ptdf_approx(model, branch_name, PTDF, rel_ptdf_tol=None
     const += PTDF.get_branch_phi_losses_adj(branch_name)
 
     max_coef = PTDF.get_branch_ldf_abs_max(branch_name)
-
-    if max_coef == 0:
-        return const
 
     ptdf_tol = max(abs_ptdf_tol, rel_ptdf_tol*max_coef) 
     ## NOTE: It would be easy to hold on to the 'ptdf' dictionary here,

--- a/egret/model_library/transmission/branch.py
+++ b/egret/model_library/transmission/branch.py
@@ -19,9 +19,6 @@ from egret.model_library.defn import FlowType, CoordinateType, ApproximationType
 from egret.data.model_data import zip_items
 from pyomo.core.util import quicksum
 
-import time
-
-
 def declare_var_dva(model, index_set, **kwargs):
     """
     Create variable or the angle difference between interconnected bus pairs
@@ -374,28 +371,22 @@ def get_power_flow_expr_ptdf_approx(model, branch_name, PTDF, rel_ptdf_tol=None,
     Create a pyomo power flow expression from PTDF matrix
     """
 
-    
-    #start_time = time.time()
-    #print("\nBuilding branch {} flow expression".format(branch_name))
     if rel_ptdf_tol is None:
         rel_ptdf_tol = 0.
     if abs_ptdf_tol is None:
         abs_ptdf_tol = 0.
-    #print("[{} s] Set tolerances".format(time.time()-start_time))
 
     const = PTDF.get_branch_phase_shift(branch_name) + PTDF.get_branch_phi_adj(branch_name)
 
     max_coef = PTDF.get_branch_ptdf_abs_max(branch_name)
-    #print("[{} s] Got branch phase shift and abs_max".format(time.time()-start_time))
+
     ## This case is weird, but could happen, causing divison by 0 below
     if max_coef == 0:
-        return expr
+        return const
     ptdf_tol = max(abs_ptdf_tol, rel_ptdf_tol*max_coef) 
     ## NOTE: It would be easy to hold on to the 'ptdf' dictionary here,
     ##       if we wanted to
     expr = quicksum( (coef*model.p_nw[bus_name] for bus_name, coef in PTDF.get_branch_ptdf_iterator(branch_name) if abs(coef) >= ptdf_tol), start=const, linear=True)
-
-    #print("[{} s] Expression built".format(time.time()-start_time))
 
     return expr
 
@@ -438,26 +429,19 @@ def get_branch_loss_expr_ptdf_approx(model, branch_name, PTDF, rel_ptdf_tol=None
     if abs_ptdf_tol is None:
         abs_ptdf_tol = 0.
 
-    expr = PTDF.get_branch_losses_phase_shift(branch_name)
-    expr += PTDF.get_branch_ldf_c(branch_name)
+    const = PTDF.get_branch_losses_phase_shift(branch_name)
+    const += PTDF.get_branch_ldf_c(branch_name)
+    const += PTDF.get_branch_phi_losses_adj(branch_name)
 
     max_coef = PTDF.get_branch_ldf_abs_max(branch_name)
 
     if max_coef == 0:
-        return expr
+        return const
 
-    ## NOTE: It would be easy to hold on to the 'ldf' dictionary here,
+    ptdf_tol = max(abs_ptdf_tol, rel_ptdf_tol*max_coef) 
+    ## NOTE: It would be easy to hold on to the 'ptdf' dictionary here,
     ##       if we wanted to
-    for bus_name, coef in PTDF.get_branch_ldf_iterator(branch_name):
-        if abs(coef) < abs_ptdf_tol:
-            ## no point in excuting the rest of the for loop
-            continue
-        if abs(coef)/max_coef < rel_ptdf_tol:
-            ## no point in excuting the rest of the for loop
-            continue
-        phi_losses_adjust = PTDF.get_bus_phi_losses_adj(bus_name)
-
-        expr += coef*model.p_nw[bus_name]+coef*phi_losses_adjust
+    expr = quicksum( (coef*model.p_nw[bus_name] for bus_name, coef in PTDF.get_branch_ldf_iterator(branch_name) if abs(coef) >= ptdf_tol), start=const, linear=True)
 
     return expr
 

--- a/egret/model_library/transmission/bus.py
+++ b/egret/model_library/transmission/bus.py
@@ -71,6 +71,12 @@ def declare_var_ql(model, index_set, **kwargs):
     """
     decl.declare_var('ql', model=model, index_set=index_set, **kwargs)
 
+def declare_var_p_nw(model, index_set, **kwargs):
+    """
+    Create variable for the reactive power load at a bus
+    """
+    decl.declare_var('p_nw', model=model, index_set=index_set, **kwargs)
+
 
 def declare_expr_shunt_power_at_bus(model, index_set, shunt_attrs,
                                     coordinate_type=CoordinateType.POLAR):
@@ -107,6 +113,20 @@ def declare_expr_p_net_withdraw_at_bus(model, index_set, bus_p_loads, gens_by_bu
         m.p_nw[b] = ( bus_gs_fixed_shunts[b] 
                     + ( m.pl[b] if bus_p_loads[b] != 0.0 else 0.0 )
                     - sum( m.pg[g] for g in gens_by_bus[b] ) )
+        
+def declare_eq_p_net_withdraw_at_bus(model, index_set, bus_p_loads, gens_by_bus, bus_gs_fixed_shunts ):
+    """
+    Create a named pyomo expression for bus net withdraw
+    """
+    m = model
+    con_set = decl.declare_set('_con_eq_p_net_withdraw_at_bus', model, index_set)
+
+    m.eq_p_net_withdraw_at_bus = pe.Constraint(con_set)
+
+    for b in index_set:
+        m.eq_p_net_withdraw_at_bus[b] = m.p_nw[b] == ( bus_gs_fixed_shunts[b] 
+                                                    + ( m.pl[b] if bus_p_loads[b] != 0.0 else 0.0 )
+                                                    - sum( m.pg[g] for g in gens_by_bus[b] ) )
                     
 def declare_eq_ref_bus_nonzero(model, ref_angle, ref_bus):
     """

--- a/egret/model_library/unit_commitment/power_balance.py
+++ b/egret/model_library/unit_commitment/power_balance.py
@@ -99,16 +99,18 @@ def _ptdf_dcopf_network_model(block,tm):
     libbus.declare_var_pl(block, m.Buses, initialize=bus_p_loads)
     block.pl.fix()
 
+    libbus.declare_var_p_nw(block, m.Buses)
+
     ### get the fixed shunts at the buses
     bus_gs_fixed_shunts = m._bus_gs_fixed_shunts
 
     ### declare net withdraw expression for use in PTDF power flows
-    libbus.declare_expr_p_net_withdraw_at_bus(model=block,
-                                              index_set=m.Buses,
-                                              bus_p_loads=bus_p_loads,
-                                              gens_by_bus=gens_by_bus,
-                                              bus_gs_fixed_shunts=bus_gs_fixed_shunts,
-                                              )
+    libbus.declare_eq_p_net_withdraw_at_bus(model=block,
+                                            index_set=m.Buses,
+                                            bus_p_loads=bus_p_loads,
+                                            gens_by_bus=gens_by_bus,
+                                            bus_gs_fixed_shunts=bus_gs_fixed_shunts,
+                                            )
 
     ### declare the p balance
     libbus.declare_eq_p_balance_ed(model=block,

--- a/egret/model_library/unit_commitment/power_balance.py
+++ b/egret/model_library/unit_commitment/power_balance.py
@@ -22,6 +22,7 @@ import egret.model_library.transmission.bus as libbus
 import egret.model_library.transmission.branch as libbranch
 import egret.model_library.transmission.gen as libgen
 import egret.data.data_utils as data_utils
+import egret.common.lazy_ptdf_utils as lpu
 
 from egret.model_library.defn import BasePointType, CoordinateType, ApproximationType
 from math import pi
@@ -153,6 +154,8 @@ def _ptdf_dcopf_network_model(block,tm):
                                                      p_thermal_limits=None,
                                                      approximation_type=None,
                                                      )
+        ### add helpers for tracking monitored branches
+        lpu.add_monitored_branch_tracker(block)
         
     else: ### add all the dense constraints
         rel_ptdf_tol = m._ptdf_options['rel_ptdf_tol']

--- a/egret/model_library/unit_commitment/uc_model_generator.py
+++ b/egret/model_library/unit_commitment/uc_model_generator.py
@@ -88,7 +88,7 @@ def _generate_model( model_data,
     model.name = "UnitCommitment"
     
     ## munge ptdf_options, if necessary
-    if _power_balance in ['lazy_ptdf_power_flow', 'ptdf_power_flow']:
+    if _power_balance in ['ptdf_power_flow']:
         import egret.common.lazy_ptdf_utils as lpu
         if _ptdf_options is None:
             _ptdf_options = dict()

--- a/egret/models/dcopf.py
+++ b/egret/models/dcopf.py
@@ -322,7 +322,7 @@ def _lazy_ptdf_dcopf_model_solve_loop(m, md, solver, timelimit, solver_tee=True,
 
     for i in range(iteration_limit):
 
-        PFV, viol_num, viols_tup = lpu.check_violations(m, PTDF)
+        PFV, viol_num, viols_tup = lpu.check_violations(m, PTDF, ptdf_options['max_violations_per_iteration'])
 
         print("iteration {0}, found {1} violation(s)".format(i,viol_num))
 

--- a/egret/models/dcopf.py
+++ b/egret/models/dcopf.py
@@ -305,15 +305,10 @@ def _lazy_ptdf_dcopf_model_solve_loop(m, md, solver, timelimit, solver_tee=True,
 
     ptdf_options = m._ptdf_options
 
-    lazy_rel_flow_tol = ptdf_options['lazy_rel_flow_tol']
-
     rel_flow_tol = ptdf_options['rel_flow_tol']
     abs_flow_tol = ptdf_options['abs_flow_tol']
 
     branch_limits = PTDF.branch_limits_array
-
-    ## if lazy_rel_flow_tol < 0, this narrows the branch limits
-    PTDF.lazy_branch_limits = branch_limits*(1+lazy_rel_flow_tol)
 
     ## only enforce the relative and absolute, within tollerance
     PTDF.enforced_branch_limits = np.maximum(branch_limits*(1+rel_flow_tol), branch_limits+abs_flow_tol)

--- a/egret/models/dcopf.py
+++ b/egret/models/dcopf.py
@@ -264,6 +264,9 @@ def create_ptdf_dcopf_model(model_data, include_feasibility_slack=False, base_po
                                                      approximation_type=None,
                                                      )
 
+        ### add helpers for tracking monitored branches
+        lpu.add_monitored_branch_tracker(model)
+
     else:
         p_max = {k: branches[k]['rating_long_term'] for k in branches.keys()}
         ## add all the constraints
@@ -317,9 +320,13 @@ def _lazy_ptdf_dcopf_model_solve_loop(m, md, solver, timelimit, solver_tee=True,
 
     for i in range(iteration_limit):
 
-        PFV, viol_num, viols_tup = lpu.check_violations(m, PTDF, ptdf_options['max_violations_per_iteration'])
+        PFV, viol_num, mon_viol_num, gt_viol_lazy, lt_viol_lazy = lpu.check_violations(m, md, PTDF, ptdf_options['max_violations_per_iteration'])
 
-        print("iteration {0}, found {1} violation(s)".format(i,viol_num))
+        iter_status_str = "iteration {0}, found {1} violation(s)".format(i,viol_num)
+        if mon_viol_num:
+            iter_status_str += ", {} of which are already monitored".format(mon_viol_num)
+
+        print(iter_status_str)
 
         if viol_num <= 0:
             ## in this case, there are no violations!
@@ -328,14 +335,14 @@ def _lazy_ptdf_dcopf_model_solve_loop(m, md, solver, timelimit, solver_tee=True,
                 solver.load_duals()
             return lpu.LazyPTDFTerminationCondition.NORMAL
 
-        all_viol_in_model = lpu.add_violations(viols_tup, PFV, m, md, solver, ptdf_options, PTDF)
-
-        if all_viol_in_model:
+        elif viol_num == mon_viol_num:
             print('WARNING: Terminating with monitored violations!')
             print('         Result is not transmission feasible.')
             if persistent_solver:
                 solver.load_duals()
             return lpu.LazyPTDFTerminationCondition.FLOW_VIOLATION
+
+        lpu.add_violations(gt_viol_lazy, lt_viol_lazy, PFV, m, md, solver, ptdf_options, PTDF)
 
         #m.ineq_pf_branch_thermal_lb.pprint()
         #m.ineq_pf_branch_thermal_ub.pprint()
@@ -345,7 +352,8 @@ def _lazy_ptdf_dcopf_model_solve_loop(m, md, solver, timelimit, solver_tee=True,
             solver.load_vars()
         else:
             solver.solve(m, tee=solver_tee, symbolic_solver_labels=symbolic_solver_labels)
-    else:
+
+    else: # we hit the iteration limit
         print('WARNING: Exiting on maximum iterations for lazy PTDF model.')
         print('         Result is not transmission feasible.')
         if persistent_solver:

--- a/egret/models/tests/test_unit_commitment.py
+++ b/egret/models/tests/test_unit_commitment.py
@@ -163,7 +163,7 @@ def test_uc_relaxation():
 
     md_in = ModelData(json.load(open(input_json_file_name, 'r')))
 
-    md_results = solve_unit_commitment(md_in, solver='cbc', relaxed=True)
+    md_results = solve_unit_commitment(md_in, solver='cbc', options={'presolve': 'off', 'primalS':''}, relaxed=True)
     reference_json_file_name = os.path.join(current_dir, 'uc_test_instances', test_name+'_relaxed_results.json')
     md_reference = ModelData(json.load(open(reference_json_file_name, 'r')))
     assert math.isclose(md_reference.data['system']['total_cost'], md_results.data['system']['total_cost'])

--- a/egret/models/tests/test_unit_commitment.py
+++ b/egret/models/tests/test_unit_commitment.py
@@ -168,6 +168,17 @@ def test_uc_relaxation():
     md_reference = ModelData(json.load(open(reference_json_file_name, 'r')))
     assert math.isclose(md_reference.data['system']['total_cost'], md_results.data['system']['total_cost'])
 
+def test_uc_ptdf_termination():
+    test_name = 'tiny_uc_tc'
+    input_json_file_name = os.path.join(current_dir, 'uc_test_instances', test_name+'.json')
+
+    md_in = ModelData(json.load(open(input_json_file_name, 'r')))
+
+    kwargs = {'ptdf_options':{'lazy': True, 'rel_ptdf_tol':10.}}
+    md_results, results = solve_unit_commitment(md_in, solver='cbc', options={'presolve': 'off', 'primalS':''}, relaxed=True, return_results=True, **kwargs)
+
+    assert results.egret_metasolver['iterations'] == 1
+
 def test_uc_ptdf_serialization_deserialization():
 
     test_name = 'tiny_uc_tc' ## based on tiny_uc_1

--- a/egret/models/unit_commitment.py
+++ b/egret/models/unit_commitment.py
@@ -580,7 +580,7 @@ def _lazy_ptdf_uc_solve_loop(m, md, solver, timelimit, solver_tee=True, symbolic
                 PTDF.enforced_branch_limits = np.maximum(branch_limits*(1+rel_flow_tol), branch_limits+abs_flow_tol)
 
             PVF[t], viol_num[t], mon_viol_num[t], gt_viol_lazy[t], lt_viol_lazy[t] = \
-                    lpu.check_violations(b, md, PTDF, ptdf_options['max_violations_per_iteration'])
+                    lpu.check_violations(b, md, PTDF, ptdf_options['max_violations_per_iteration'], time=t)
 
         total_viol_num = sum(viol_num.values())
         total_mon_viol_num = sum(mon_viol_num.values())

--- a/egret/models/unit_commitment.py
+++ b/egret/models/unit_commitment.py
@@ -579,7 +579,7 @@ def _lazy_ptdf_uc_solve_loop(m, md, solver, timelimit, solver_tee=True, symbolic
                 ## only enforce the relative and absolute, within tollerance
                 PTDF.enforced_branch_limits = np.maximum(branch_limits*(1+rel_flow_tol), branch_limits+abs_flow_tol)
 
-            PVF[t], viol_num[t], viols_tup[t] = lpu.check_violations(b, PTDF)
+            PVF[t], viol_num[t], viols_tup[t] = lpu.check_violations(b, PTDF, ptdf_options['max_violations_per_iteration'])
 
         total_viol_num = sum(val for val in viol_num.values())
         print("iteration {0}, found {1} violation(s)".format(i,total_viol_num))

--- a/egret/models/unit_commitment.py
+++ b/egret/models/unit_commitment.py
@@ -16,6 +16,7 @@ unit commitment formulations
 
 from egret.model_library.unit_commitment.uc_model_generator \
         import UCFormulation, generate_model 
+from egret.common.log import logger
 from egret.model_library.transmission.tx_utils import \
         scale_ModelData_to_pu, unscale_ModelData_to_pu
 from pyomo.solvers.plugins.solvers.persistent_solver import PersistentSolver
@@ -589,15 +590,14 @@ def _lazy_ptdf_uc_solve_loop(m, md, solver, timelimit, solver_tee=True, symbolic
         if total_mon_viol_num:
             iter_status_str += ", {} of which are already monitored".format(total_mon_viol_num)
 
-        print(iter_status_str)
+        logger.info(iter_status_str)
 
         if total_viol_num <= 0:
             if persistent_solver and duals and results is not None and vars_to_load is None:
                 solver.load_duals()
             return lpu.LazyPTDFTerminationCondition.NORMAL, results, i
         elif total_viol_num == total_mon_viol_num:
-            print('WARNING: Terminating with monitored violations!')
-            print('         Result is not transmission feasible.')
+            logger.warning('WARNING: Terminating with monitored violations! Result is not transmission feasible.')
             if persistent_solver and duals:
                 solver.load_duals()
             return lpu.LazyPTDFTerminationCondition.FLOW_VIOLATION, results, i
@@ -619,8 +619,7 @@ def _lazy_ptdf_uc_solve_loop(m, md, solver, timelimit, solver_tee=True, symbolic
 
     else:
         if warn_on_max_iter:
-            print('WARNING: Exiting on maximum iterations for lazy PTDF model.')
-            print('         Result is not transmission feasible.')
+            logger.warning('WARNING: Exiting on maximum iterations for lazy PTDF model. Result is not transmission feasible.')
         if persistent_solver and duals:
             solver.load_duals()
         return lpu.LazyPTDFTerminationCondition.ITERATION_LIMIT, results, i
@@ -1212,7 +1211,7 @@ def solve_unit_commitment(model_data,
                 for dt, mt in zip(data_time_periods, m.TimePeriods):
                     fuel_consumed[dt] = value(m.TotalFuelConsumedAtInstFuelSupply[f,mt])
             else:
-                print('WARNING: unrecongized fuel_supply_type {} for fuel_supply {}'.format(fuel_supply_type, f))
+                logger.warning('WARNING: unrecongized fuel_supply_type {} for fuel_supply {}'.format(fuel_supply_type, f))
             f_dict['fuel_consumed'] = _time_series_dict(fuel_consumed)
 
     md.data['system']['total_cost'] = value(m.TotalCostObjective)


### PR DESCRIPTION
This PR makes several changes related to building and solving transmission models using PTDFs.
1. Putting more constant multiplications into numpy.
1. Creating a pyomo Var `p_nw` and associated Constraint for bus net withdraw. This moves the arithmetic for this into the solver.
1. Using `LinearExpression` for dense PTDF constraints.
1. Minimizing the work done between solver calls for lazy PTDF by only loading in needed variable values `p_nw` when using persistent solvers
1. Separating out the outer lazy PTDF solve loop in unit_commitment.py
1. Changing the logic of which PTDF constraints get added -- default now only adds one constraint (per time period) per iteration. Can be set with `max_violations_per_iteration` option.
1. Eliminating `lazy_rel_flow_tol` option and associated code.