### PR TITLE
Using dual_fuel_attrs where appropriate

### DIFF
--- a/egret/model_library/unit_commitment/fuel_consumption.py
+++ b/egret/model_library/unit_commitment/fuel_consumption.py
@@ -123,9 +123,9 @@ def fuel_consumption_model(model):
     ## load and verify some parameters
     dual_fuel_attrs = md.attributes(element_type='generator', generator_type='thermal', aux_fuel_capable=True)
 
-    model.UnitSwitchOperating = Param(model.DualFuelGenerators, within=Boolean, default=False, initialize=thermal_gen_attrs.get('aux_fuel_online_switching'))
+    model.UnitSwitchOperating = Param(model.DualFuelGenerators, within=Boolean, default=False, initialize=dual_fuel_attrs.get('aux_fuel_online_switching'))
 
-    model.UnitFuelBlending = Param(model.DualFuelGenerators, within=Boolean, default=False, initialize=thermal_gen_attrs.get('aux_fuel_blending'))
+    model.UnitFuelBlending = Param(model.DualFuelGenerators, within=Boolean, default=False, initialize=dual_fuel_attrs.get('aux_fuel_blending'))
 
     def verify_dual_fuel_consistency(m, g):
         if value(m.UnitFuelBlending[g]) and not value(m.UnitSwitchOperating[g]):
@@ -136,7 +136,7 @@ def fuel_consumption_model(model):
     
     def verify_initial_fuel_defined(m, g):
         if not value(m.UnitSwitchOperating[g]) and value(m.UnitOnT0[g]):
-            if 'aux_fuel_supply_initial' not in thermal_gen_attrs or g not in thermal_gen_attrs['aux_fuel_supply_initial']:
+            if 'aux_fuel_supply_initial' not in dual_fuel_attrs or g not in dual_fuel_attrs['aux_fuel_supply_initial']:
                 print("DATA ERROR: Couldn't find initial fuel for dual fuel generator "+g)
                 assert(False)
     model.VerifyUnitInitialFuelDefined = BuildAction(model.DualFuelGenerators, rule=verify_initial_fuel_defined)


### PR DESCRIPTION
Fixes an issue where generators which are not dual fuel where causing model build issues for dual fuel generator parameters, if they had certain parameters set.

This PR uses the dual_fuel_attrs slice everywhere appropriate.