### PR TITLE
Enabling last time periods for rts_gmlc_parser

### DIFF
--- a/egret/parsers/rts_gmlc_parser.py
+++ b/egret/parsers/rts_gmlc_parser.py
@@ -725,7 +725,7 @@ def _get_datetimes(begin_time, end_time):
 
     # stay in the times provided
     assert begin_time >= datetime(year=2020, month=1, day=1)
-    assert end_time < datetime(year=2021, month=1, day=1)
+    assert end_time <= datetime(year=2021, month=1, day=1)
 
     # We only take times in whole hours (for now)
     assert (begin_time.minute == 0. and begin_time.second == 0. and begin_time.microsecond == 0.)


### PR DESCRIPTION
As-is, one could not get the last few time periods when using the provided RTS-GMLC parser. This PR fixes that issue.