### PR TITLE
[WIP] PTDF calculation performance improvements

### DIFF
--- a/egret/common/lazy_ptdf_utils.py
+++ b/egret/common/lazy_ptdf_utils.py
@@ -79,7 +79,7 @@ def add_monitored_branch_tracker(mb):
 ## violation checker
 def check_violations(mb, md, PTDF, max_viol_add, time=None):
 
-    NWV = np.array([pe.value(mb.p_nw[b]) for b in PTDF.bus_iterator()])
+    NWV = np.fromiter((pe.value(mb.p_nw[b]) for b in PTDF.bus_iterator()), float, count=len(PTDF.buses_keys))
     NWV += PTDF.phi_adjust_array
 
     PFV  = PTDF.PTDFM.dot(NWV)

--- a/egret/data/data_utils.py
+++ b/egret/data/data_utils.py
@@ -118,7 +118,8 @@ class PTDFMatrix(object):
         do the PTDF calculation
         '''
         ## calculate and store the PTDF matrix
-        PTDFM = tx_calc.calculate_ptdf(self._branches,self._buses,self.branches_keys,self.buses_keys,self._reference_bus,self._base_point)
+        PTDFM = tx_calc.calculate_ptdf(self._branches,self._buses,self.branches_keys,self.buses_keys,self._reference_bus,self._base_point,
+                                        mapping_bus_to_idx=self._busname_to_index_map)
 
         self.PTDFM = PTDFM.toarray()
 
@@ -126,7 +127,7 @@ class PTDFMatrix(object):
         self.PTDFM.flags.writeable = False
 
     def _calculate_phi_from_phi_to(self):
-        return tx_calc.calculate_phi_constant(self._branches,self.branches_keys,self.buses_keys,ApproximationType.PTDF)
+        return tx_calc.calculate_phi_constant(self._branches,self.branches_keys,self.buses_keys,ApproximationType.PTDF, mapping_bus_to_idx=self._busname_to_index_map)
 
     def _calculate_phi_adjust(self):
         phi_from, phi_to = self._calculate_phi_from_phi_to()
@@ -190,7 +191,8 @@ class PTDFLossesMatrix(PTDFMatrix):
         self._calculate_losses_phase_shift()
 
     def _calculate_ptdf(self):
-        ptdf_r, ldf, ldf_c = tx_calc.calculate_ptdf_ldf(self._branches,self._buses,self.branches_keys,self.buses_keys,self._reference_bus,self._base_point)
+        ptdf_r, ldf, ldf_c = tx_calc.calculate_ptdf_ldf(self._branches,self._buses,self.branches_keys,self.buses_keys,self._reference_bus,self._base_point,\
+                                                        mapping_bus_to_idx=self._busname_to_index_map)
 
         self.PTDFM = ptdf_r.toarray()
         self.LDF = ldf.toarray()
@@ -202,10 +204,10 @@ class PTDFLossesMatrix(PTDFMatrix):
         self.LDF_C.flags.writeable = False
 
     def _calculate_phi_from_phi_to(self):
-        return tx_calc.calculate_phi_constant(self._branches,self.branches_keys,self.buses_keys,ApproximationType.PTDF_LOSSES)
+        return tx_calc.calculate_phi_constant(self._branches,self.branches_keys,self.buses_keys,ApproximationType.PTDF_LOSSES, mapping_bus_to_idx=self._busname_to_index_map)
 
     def _calculate_phi_loss_constant(self):
-        phi_loss_from, phi_loss_to = tx_calc.calculate_phi_loss_constant(self._branches,self.branches_keys,self.buses_keys,ApproximationType.PTDF_LOSSES)
+        phi_loss_from, phi_loss_to = tx_calc.calculate_phi_loss_constant(self._branches,self.branches_keys,self.buses_keys,ApproximationType.PTDF_LOSSES, mapping_bus_to_idx=self._busname_to_index_map)
 
         ## hold onto these for line outages
         self._phi_loss_from = phi_loss_from

--- a/egret/data/data_utils.py
+++ b/egret/data/data_utils.py
@@ -121,7 +121,7 @@ class PTDFMatrix(object):
         PTDFM = tx_calc.calculate_ptdf(self._branches,self._buses,self.branches_keys,self.buses_keys,self._reference_bus,self._base_point,
                                         mapping_bus_to_idx=self._busname_to_index_map)
 
-        self.PTDFM = PTDFM.toarray()
+        self.PTDFM = PTDFM
 
         ## protect the array using numpy
         self.PTDFM.flags.writeable = False
@@ -194,8 +194,8 @@ class PTDFLossesMatrix(PTDFMatrix):
         ptdf_r, ldf, ldf_c = tx_calc.calculate_ptdf_ldf(self._branches,self._buses,self.branches_keys,self.buses_keys,self._reference_bus,self._base_point,\
                                                         mapping_bus_to_idx=self._busname_to_index_map)
 
-        self.PTDFM = ptdf_r.toarray()
-        self.LDF = ldf.toarray()
+        self.PTDFM = ptdf_r
+        self.LDF = ldf
         self.LDF_C = ldf_c
 
         ## protect the arrays using numpy

--- a/egret/data/data_utils.py
+++ b/egret/data/data_utils.py
@@ -136,10 +136,11 @@ class PTDFMatrix(object):
         self._phi_from = phi_from
         self._phi_to = phi_to
 
-        ## sum the across the columns, which are indexed by branch
-        phi_adjust_array = phi_from.sum(axis=1)-phi_to.sum(axis=1)
+        phi_adjust_array = phi_from-phi_to
 
-        self.phi_adjust_array = phi_adjust_array
+        ## sum across the rows to get the total impact, and convert
+        ## to dense for fast operations later
+        self.phi_adjust_array = phi_adjust_array.sum(axis=1).T.A[0]
 
         ## protect the array using numpy
         self.phi_adjust_array.flags.writeable = False
@@ -214,9 +215,11 @@ class PTDFLossesMatrix(PTDFMatrix):
         self._phi_loss_to = phi_loss_to
 
         ## sum the across the columns, which are indexed by branch
-        phi_losses_adjust_array = phi_loss_from.sum(axis=1)-phi_loss_to.sum(axis=1)
+        phi_losses_adjust_array = phi_loss_from-phi_loss_to
 
-        self.phi_losses_adjust_array = phi_losses_adjust_array
+        ## sum across the rows to get the total impact, and convert
+        ## to dense for fast operations later
+        self.phi_losses_adjust_array = phi_losses_adjust_array.sum(axis=1).T.A[0]
 
         ## protect the array using numpy
         self.phi_losses_adjust_array.flags.writeable = False

--- a/egret/data/data_utils.py
+++ b/egret/data/data_utils.py
@@ -99,7 +99,7 @@ class PTDFMatrix(object):
         self._branchname_to_index_map = {branch_n : i for i, branch_n in enumerate(self.branches_keys)}
         self._busname_to_index_map = {bus_n : j for j, bus_n in enumerate(self.buses_keys)}
 
-        self.branch_limits_array = np.array([branches[branch]['rating_long_term'] for branch in self.branches_keys])
+        self.branch_limits_array = np.fromiter((branches[branch]['rating_long_term'] for branch in self.branches_keys), float, count=len(self.branches_keys))
         self.branch_limits_array.flags.writeable = False
 
         self._base_point = base_point
@@ -145,7 +145,7 @@ class PTDFMatrix(object):
 
     def _calculate_phase_shift(self):
         
-        phase_shift_array = np.array([ -(1/branch['reactance']) * (radians(branch['transformer_phase_shift'])/branch['transformer_tap_ratio']) if (branch['branch_type'] == 'transformer') else 0. for branch in (self._branches[bn] for bn in self.branches_keys)])
+        phase_shift_array = np.fromiter(( -(1/branch['reactance']) * (radians(branch['transformer_phase_shift'])/branch['transformer_tap_ratio']) if (branch['branch_type'] == 'transformer') else 0. for branch in (self._branches[bn] for bn in self.branches_keys)), float, count=len(self.branches_keys))
 
         self.phase_shift_array = phase_shift_array
         ## protect the array using numpy
@@ -221,10 +221,10 @@ class PTDFLossesMatrix(PTDFMatrix):
 
     def _calculate_phase_shift(self):
         
-        phase_shift_array = np.array([ tx_calc.calculate_susceptance(branch) * (radians(branch['transformer_phase_shift'])/branch['transformer_tap_ratio']) 
+        phase_shift_array = np.fromiter(( tx_calc.calculate_susceptance(branch) * (radians(branch['transformer_phase_shift'])/branch['transformer_tap_ratio']) 
             if (branch['branch_type'] == 'transformer') 
             else 0. 
-            for branch in (self._branches[bn] for bn in self.branches_keys)])
+            for branch in (self._branches[bn] for bn in self.branches_keys)), float, count=len(self.branches_keys))
 
         self.phase_shift_array = phase_shift_array
 
@@ -233,10 +233,10 @@ class PTDFLossesMatrix(PTDFMatrix):
 
     def _calculate_losses_phase_shift(self):
 
-        losses_phase_shift_array = np.array([ (tx_calc.calculate_conductance(branch)/branch['transformer_tap_ratio']) * radians(branch['transformer_phase_shift'])**2 
+        losses_phase_shift_array = np.fromiter(( (tx_calc.calculate_conductance(branch)/branch['transformer_tap_ratio']) * radians(branch['transformer_phase_shift'])**2 
             if branch['branch_type'] == 'transformer' 
             else 0.
-            for branch in (self._branches[bn] for bn in self.branches_keys)])
+            for branch in (self._branches[bn] for bn in self.branches_keys)), float, count=len(self.branches_keys))
 
         self.losses_phase_shift_array = losses_phase_shift_array
 

--- a/egret/models/tests/test_dcopf.py
+++ b/egret/models/tests/test_dcopf.py
@@ -81,6 +81,8 @@ class TestDCOPF(unittest.TestCase):
         md_serialization, results = solve_dcopf(md_dict, "ipopt", dcopf_model_generator=dcopf_model, solver_tee=False, return_results=True, **kwargs)
         self.assertTrue(results.solver.termination_condition == TerminationCondition.optimal)
 
+        self.assertTrue(os.path.isfile(test_case+'.pickle'))
+
         kwargs = {'ptdf_options': {'load_from': test_case+'.pickle'}}
         md_deserialization, results = solve_dcopf(md_dict, "ipopt", dcopf_model_generator=dcopf_model, solver_tee=False, return_results=True, **kwargs)
         self.assertTrue(results.solver.termination_condition == TerminationCondition.optimal)


### PR DESCRIPTION
This PR makes several modifications to the way PTDFs are calculated. The main changes are
1. Use of numpy.fromiter to avoid creating intermediate lists
1. Only calculating the mapping from bus name to bus index once
1. Using scipy spare matrices where the matrix will likely be or is sparse
1. Using numpy dense matrices where the matrix will likely be or is dense
1. Building needed intermediary matrices using `scipy.sparse.coo_matrix`, when sparse.

Limitations
1. The return types of the matrices from `tx_calc.calculate_ptdf` and `tx_calc.calculate_ptdf_ldf` now depend on if the option `sparse_index_set_branch` is set. If so, the returned matrices will be in a scipy sparse matrix format. If not, they will be numpy dense matrices.