### PR TITLE
Making uc_model_generator.generate_model more user-friendly

### DIFF
--- a/egret/model_library/unit_commitment/uc_model_generator.py
+++ b/egret/model_library/unit_commitment/uc_model_generator.py
@@ -79,6 +79,8 @@ def _generate_model( model_data,
                     _ptdf_options = None,
                     ):
 
+    md = model_data.clone_in_service()
+    scale_ModelData_to_pu(md, inplace=True)
     
     model = pe.ConcreteModel()
 

--- a/egret/model_library/unit_commitment/uc_model_generator.py
+++ b/egret/model_library/unit_commitment/uc_model_generator.py
@@ -18,7 +18,7 @@ from egret.model_library.unit_commitment import \
         uptime_downtime, startup_costs, \
         services, power_balance, reserve_requirement, \
         objective, fuel_supply, fuel_consumption
-
+from egret.model_library.transmission.tx_utils import scale_ModelData_to_pu
 from collections import namedtuple
 import pyomo.environ as pe
 
@@ -60,7 +60,9 @@ def generate_model( model_data, uc_formulation, relax_binaries=False, ptdf_optio
                                       from model_data
     """
 
-    return _generate_model( model_data, *_get_formulation_from_UCFormulation( uc_formulation ), relax_binaries , ptdf_options )
+    md = model_data.clone_in_service()
+    scale_ModelData_to_pu(md, inplace=True)
+    return _generate_model( md, *_get_formulation_from_UCFormulation( uc_formulation ), relax_binaries , ptdf_options )
 
 def _generate_model( model_data,
                     _status_vars,
@@ -78,9 +80,6 @@ def _generate_model( model_data,
                     _relax_binaries = False,
                     _ptdf_options = None,
                     ):
-
-    md = model_data.clone_in_service()
-    scale_ModelData_to_pu(md, inplace=True)
     
     model = pe.ConcreteModel()
 

--- a/egret/models/unit_commitment.py
+++ b/egret/models/unit_commitment.py
@@ -28,8 +28,6 @@ import numpy as np
 
 def _get_uc_model(model_data, formulation_list, relax_binaries, **kwargs):
     formulation = UCFormulation(*formulation_list)
-    md = model_data.clone_in_service()
-    scale_ModelData_to_pu(md, inplace=True)
     return generate_model(md, formulation, relax_binaries, **kwargs)
 
 def create_tight_unit_commitment_model(model_data,

--- a/egret/models/unit_commitment.py
+++ b/egret/models/unit_commitment.py
@@ -17,8 +17,7 @@ unit commitment formulations
 from egret.model_library.unit_commitment.uc_model_generator \
         import UCFormulation, generate_model 
 from egret.common.log import logger
-from egret.model_library.transmission.tx_utils import \
-        scale_ModelData_to_pu, unscale_ModelData_to_pu
+from egret.model_library.transmission.tx_utils import unscale_ModelData_to_pu
 from pyomo.solvers.plugins.solvers.persistent_solver import PersistentSolver
 
 import egret.common.lazy_ptdf_utils as lpu
@@ -28,7 +27,7 @@ import numpy as np
 
 def _get_uc_model(model_data, formulation_list, relax_binaries, **kwargs):
     formulation = UCFormulation(*formulation_list)
-    return generate_model(md, formulation, relax_binaries, **kwargs)
+    return generate_model(model_data, formulation, relax_binaries, **kwargs)
 
 def create_tight_unit_commitment_model(model_data,
                                        network_constraints='ptdf_power_flow',


### PR DESCRIPTION
This PR moves where the ModelData object is copied and scaled so that `egret.model_library.unit_commitment.uc_model_generator.generate_model` can be called by users without necessitating calling other functions.