### PR TITLE
[WIP] Stack graph generation enhancements

### DIFF
--- a/egret/viz/generate_graphs.py
+++ b/egret/viz/generate_graphs.py
@@ -344,7 +344,7 @@ def generate_stack_graph(egret_model_data, bar_width=0.9,
                     # Assign a hatching symbol to indicate the generation was on auxiliary fuel. This gets augmented for quickstart generators, if applicable.
                     hatch_symbol = {}
                     hatch_symbol['primary'] = ''
-                    hatch_symbol['aux'] = '/..'
+                    hatch_symbol['aux'] = '-..'
 
                     for operation_type in ['primary', 'aux']:
                         _, l = ax.get_legend_handles_labels()


### PR DESCRIPTION
# Dual fuel generators
* Recognizing dual fuel generators (aux_fuel_capable == True) and stacking separately
* Indicating when aux fuel is in use
* TODO: Apply these enhancements for all display modes (show individual generators in stack components, show individual generators)

# Other enhancements
* Fixing an issue where the y-axis max limit was set to exactly the tallest stack's height. The y-axis max value is now 105% of the tallest stack's height.

# Preview
The '-..' hatch pattern indicates the portion of generation from dual fuel generators that are operating using auxiliary fuel at the time. In other words, if a dual fuel generator at time t is consuming any aux. fuel, its contribution to the stack at time t will be hatched. The quickstart hatch pattern will augment this hatch pattern, if applicable.

![Figure_5](https://user-images.githubusercontent.com/23531868/66953889-8bfee880-f01c-11e9-8865-bd36304e1f07.png)
