### PR TITLE
Demoting Exceptions in add_model_attr to warnings

### DIFF
--- a/egret/model_library/unit_commitment/uc_utils.py
+++ b/egret/model_library/unit_commitment/uc_utils.py
@@ -16,6 +16,9 @@ working with unit commitment models
 ## some useful function decorators for building these dynamic models
 from functools import wraps
 
+import logging
+logger = logging.getLogger('egret.model_library.unit_commitment.uc_utils')
+
 def add_model_attr(attr, requires = {}):
     def actual_decorator(func):
         @wraps(func)
@@ -23,16 +26,16 @@ def add_model_attr(attr, requires = {}):
             ## tag this function in the model with the appropriate attribute
             model = args[0]
             if hasattr(model, attr):
-                raise Exception("Exception adding %s! Model already has %s %s! You may only add one type of %s!"%(func.__name__, attr, getattr(model,attr), attr)) 
+                raise logger.warning("Warning: adding %s! Model already has %s %s! You may only add one type of %s!"%(func.__name__, attr, getattr(model,attr), attr)) 
             # this checks to see if the required components were already added
             for base_attr in requires:
                 if not hasattr(model, base_attr):
-                    raise Exception("Exception adding %s! %s requires some %s to be added first!"%(func.__name__, func.__name__, base_attr)) 
+                    raise logger.warning("Warning: adding %s! %s requires some %s to be added first!"%(func.__name__, func.__name__, base_attr)) 
                 ## None in this context means there is no specific requirement
                 if requires[base_attr] is None:
                     continue
                 if getattr(model, base_attr) not in requires[base_attr]:
-                    raise Exception("Exception adding %s! %s requires one of: "%(func.__name__, func.__name__) + ", ".join(requires[base_attr]) + ", to be added first.")
+                    raise logger.warning("Warning: adding %s! %s requires one of: "%(func.__name__, func.__name__) + ", ".join(requires[base_attr]) + ", to be added first.")
             setattr(model, attr, func.__name__)
             return func(*args, **kwds)
         return wrapper


### PR DESCRIPTION
The changes the behavior of the high-level unit commitment model consistency checker to only issue warnings instead of Exceptions.

Users who wish to construct a full unit commitment model from model_library should be using `egret.model_library.unit_commitment.uc_model_generator.generate_model`, which enforces this consistencies, instead of calling the other modules in egret.model_library.unit_commitment.

This frees the other modules in `egret.model_library.unit_commitment` to be used only partially or in other ways, provided the user attaches the correct objects to the underlying pyomo model.