### PR TITLE
Changes to unit commitment model for pyomo PR #1272

### DIFF
--- a/egret/model_library/unit_commitment/fuel_consumption.py
+++ b/egret/model_library/unit_commitment/fuel_consumption.py
@@ -123,9 +123,9 @@ def fuel_consumption_model(model):
     ## load and verify some parameters
     dual_fuel_attrs = md.attributes(element_type='generator', generator_type='thermal', aux_fuel_capable=True)
 
-    model.UnitSwitchOperating = Param(model.DualFuelGenerators, within=Boolean, default=False, initialize=dual_fuel_attrs.get('aux_fuel_online_switching'))
+    model.UnitSwitchOperating = Param(model.DualFuelGenerators, within=Boolean, default=False, initialize=dual_fuel_attrs.get('aux_fuel_online_switching', dict()))
 
-    model.UnitFuelBlending = Param(model.DualFuelGenerators, within=Boolean, default=False, initialize=dual_fuel_attrs.get('aux_fuel_blending'))
+    model.UnitFuelBlending = Param(model.DualFuelGenerators, within=Boolean, default=False, initialize=dual_fuel_attrs.get('aux_fuel_blending', dict()))
 
     def verify_dual_fuel_consistency(m, g):
         if value(m.UnitFuelBlending[g]) and not value(m.UnitSwitchOperating[g]):
@@ -162,9 +162,9 @@ def fuel_consumption_model(model):
 
     model.AuxiliaryFuelCost = Param(model.DualFuelGenerators, initialize=dual_fuel_attrs['aux_fuel_cost'], within=NonNegativeReals)
 
-    model.NonFuelNoLoadCost = Param(model.DualFuelGenerators, initialize=dual_fuel_attrs.get('non_fuel_no_load_cost'), default=0., within=Reals)
+    model.NonFuelNoLoadCost = Param(model.DualFuelGenerators, initialize=dual_fuel_attrs.get('non_fuel_no_load_cost', dict()), default=0., within=Reals)
 
-    model.NonFuelStartupCost = Param(model.DualFuelGenerators, initialize=dual_fuel_attrs.get('non_fuel_startup_cost'), default=0., within=Reals)
+    model.NonFuelStartupCost = Param(model.DualFuelGenerators, initialize=dual_fuel_attrs.get('non_fuel_startup_cost', dict()), default=0., within=Reals)
 
     def dual_fuel_startup_running_cost(m,g,t):
         return m.PrimaryFuelCost[g]*m.PrimaryFuelConsumedCommitment[g,t] \

--- a/egret/model_library/unit_commitment/fuel_consumption.py
+++ b/egret/model_library/unit_commitment/fuel_consumption.py
@@ -10,7 +10,7 @@
 from pyomo.environ import *
 import math
 
-from .uc_utils import add_model_attr, uc_time_helper 
+from .uc_utils import add_model_attr
 from .status_vars import _is_relaxed
 
 @add_model_attr('fuel_consumption', requires = {'data_loader': None,
@@ -33,11 +33,6 @@ def fuel_consumption_model(model):
     '''
 
     md = model.model_data
-
-    system = md.data['system']
-    time_keys = system['time_keys']
-    TimeMapper = uc_time_helper
-
 
     relaxed = _is_relaxed(model)
     ## generator fuel consumption model

--- a/egret/model_library/unit_commitment/fuel_supply.py
+++ b/egret/model_library/unit_commitment/fuel_supply.py
@@ -26,9 +26,7 @@ def fuel_supply_model(model):
     '''
     md = model.model_data
 
-    system = md.data['system']
-    time_keys = system['time_keys']
-    TimeMapper = uc_time_helper
+    TimeMapper = uc_time_helper(model.TimePeriods)
 
     ## instantaneous fuel supply model
     inst_fuel_supply_attrs = md.attributes(element_type='fuel_supply', fuel_supply_type='instantaneous')

--- a/egret/model_library/unit_commitment/params.py
+++ b/egret/model_library/unit_commitment/params.py
@@ -84,7 +84,6 @@ def load_params(model, model_data):
     elements = md.data['elements']
 
     time_keys = system['time_keys']
-    TimeMapper = uc_time_helper
     
     ## insert potentially missing keys
     if 'branch' not in elements:
@@ -168,6 +167,8 @@ def load_params(model, model_data):
     
     model.InitialTime = Param(within=PositiveIntegers, default=1)
     model.TimePeriods = RangeSet(model.InitialTime, model.NumTimePeriods)
+
+    TimeMapper = uc_time_helper(model.TimePeriods)
     
     ## For now, hard code these. Probably need to be able to specify in model_data
     model.StageSet = Set(ordered=True, initialize=['Stage_1', 'Stage_2']) 
@@ -298,7 +299,7 @@ def load_params(model, model_data):
         bus = load['bus']
         load_time = TimeMapper(load['p_load'])
         for t in model.TimePeriods:
-            bus_loads[bus, t] += load_time(None,t)
+            bus_loads[bus, t] += load_time[t]
     model.Demand = Param(model.Buses, model.TimePeriods, initialize=bus_loads, mutable=True)
     
     def calculate_total_demand(m, t):

--- a/egret/model_library/unit_commitment/services.py
+++ b/egret/model_library/unit_commitment/services.py
@@ -182,8 +182,7 @@ def ancillary_services(model):
     system = md.data['system']
     elements = md.data['elements']
 
-    time_keys = system['time_keys']
-    TimeMapper = uc_time_helper
+    TimeMapper = uc_time_helper(model.TimePeriods)
 
 
     ## list of possible ancillary services coming
@@ -279,14 +278,14 @@ def ancillary_services(model):
             az_n = str(az)
             if az_n[:5] == 'zone_':
                 z_n = az_n[5:]
-                if z_n in zone_attrs[reserve_product]:
-                    return zone_r_time(m,z_n,t)
+                if (z_n,t) in zone_r_time:
+                    return zone_r_time[z_n,t]
                 else:
                     return 0.0
             elif az_n[:5] == 'area_':
                 a_n = az_n[5:]
-                if a_n in area_attrs[reserve_product]:
-                    return area_r_time(m,a_n,t)
+                if (a_n,t) in area_r_time:
+                    return area_r_time[a_n,t]
                 else:
                     return 0.0
             else:
@@ -429,8 +428,7 @@ def regulation_services(model, zone_initializer_builder, zone_requirement_getter
 
     system = md.data['system']
 
-    time_keys = system['time_keys']
-    TimeMapper = uc_time_helper
+    TimeMapper = uc_time_helper(model.TimePeriods)
 
     def _check_reg(e_dict):
         return ( ('regulation_up_requirement' in e_dict) \
@@ -600,8 +598,7 @@ def spinning_reserves(model, zone_initializer_builder, zone_requirement_getter, 
 
     system = md.data['system']
 
-    time_keys = system['time_keys']
-    TimeMapper = uc_time_helper
+    TimeMapper = uc_time_helper(model.TimePeriods)
 
     def _check_spin(e_dict):
         return 'spinning_reserve_requirement' in e_dict
@@ -696,8 +693,7 @@ def non_spinning_reserves(model, zone_initializer_builder, zone_requirement_gett
 
     system = md.data['system']
 
-    time_keys = system['time_keys']
-    TimeMapper = uc_time_helper
+    TimeMapper = uc_time_helper(model.TimePeriods)
 
     def _check_nspin(e_dict):
         return 'non_spinning_reserve_requirement' in e_dict
@@ -796,8 +792,7 @@ def supplemental_reserves(model, zone_initializer_builder, zone_requirement_gett
 
     system = md.data['system']
 
-    time_keys = system['time_keys']
-    TimeMapper = uc_time_helper
+    TimeMapper = uc_time_helper(model.TimePeriods)
 
     def _check_supplemental(e_dict):
         return 'supplemental_reserve_requirement' in e_dict
@@ -931,8 +926,7 @@ def flexible_ramping_reserves(model, zone_initializer_builder, zone_requirement_
 
     system = md.data['system']
 
-    time_keys = system['time_keys']
-    TimeMapper = uc_time_helper
+    TimeMapper = uc_time_helper(model.TimePeriods)
 
     def _check_flex(e_dict):
         return ( ('flexible_ramp_up_requirement' in e_dict) \

--- a/egret/model_library/unit_commitment/services.py
+++ b/egret/model_library/unit_commitment/services.py
@@ -233,26 +233,27 @@ def ancillary_services(model):
     if model.status_vars not in ['garver_3bin_vars','garver_2bin_vars', 'garver_3bin_relaxed_stop_vars', 'ALS_state_transition_vars']:
         raise Exception('Exception adding ancillary_services! ancillary_services requires one of: garver_3bin_vars, garver_2bin_vars, garver_3bin_relaxed_stop_vars, ALS_state_transition_vars, to be used for the status_vars.')
 
+    ## set some penalties by default based on the other model penalties
+    default_reg_pen = value(model.LoadMismatchPenalty+model.ReserveShortfallPenalty)/2.
     ## set these penalties in relation to each other, from higher quality service to lower
     model.RegulationPenalty = Param(within=NonNegativeReals,
-                                    default=value(model.LoadMismatchPenalty+model.ReserveShortfallPenalty)/2.,
-                                    initialize=system.get('regulation_penalty_price'))
+                                    initialize=system.get('regulation_penalty_price', default_reg_pen))
 
+    default_spin_pen = value(model.RegulationPenalty+model.ReserveShortfallPenalty)/2.
     model.SpinningReservePenalty = Param(within=NonNegativeReals, 
-                                         default=value(model.RegulationPenalty+model.ReserveShortfallPenalty)/2.,
-                                         initialize=system.get('spinning_reserve_penalty_price'))
+                                         initialize=system.get('spinning_reserve_penalty_price', default_spin_pen))
 
+    default_nspin_pen = value(model.SpinningReservePenalty+model.ReserveShortfallPenalty)/2.
     model.NonSpinningReservePenalty = Param(within=NonNegativeReals,
-                                            default=value(model.SpinningReservePenalty+model.ReserveShortfallPenalty)/2.,
-                                            initialize=system.get('non_spinning_reserve_penalty_price'))
+                                            initialize=system.get('non_spinning_reserve_penalty_price', default_nspin_pen))
 
+    default_supp_pen = value(model.NonSpinningReservePenalty+model.ReserveShortfallPenalty)/2.
     model.SupplementalReservePenalty = Param(within=NonNegativeReals,
-                                             default=value(model.NonSpinningReservePenalty+model.ReserveShortfallPenalty)/2.,
-                                             initialize=system.get('supplemental_reserve_penalty_price'))
+                                             initialize=system.get('supplemental_reserve_penalty_price', default_supp_pen))
 
+    default_flex_pen = value(model.NonSpinningReservePenalty+model.SpinningReservePenalty)/2.
     model.FlexRampPenalty = Param(within=NonNegativeReals,
-                                  default=value(model.NonSpinningReservePenalty+model.SpinningReservePenalty)/2.,
-                                  initialize=system.get('flexible_ramp_penalty_price'))
+                                  initialize=system.get('flexible_ramp_penalty_price', default_flex_pen))
 
     thermal_gen_attrs = md.attributes(element_type='generator', generator_type='thermal')
     
@@ -477,19 +478,19 @@ def regulation_services(model, zone_initializer_builder, zone_requirement_getter
     model.ZonalRegulationUpRequirement = Param(model.RegulationZones, model.TimePeriods, within=NonNegativeReals, 
                                                     initialize=zone_requirement_getter('regulation_up_requirement'))
     
-    model.SystemRegulationUpRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('regulation_up_requirement')))
+    model.SystemRegulationUpRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('regulation_up_requirement', dict())))
 
     model.ZonalRegulationDnRequirement = Param(model.RegulationZones, model.TimePeriods, within=NonNegativeReals,
                                                     initialize=zone_requirement_getter('regulation_down_requirement'))
 
-    model.SystemRegulationDnRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('regulation_down_requirement')))
+    model.SystemRegulationDnRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('regulation_down_requirement', dict())))
 
     def validate_fixed_reg(m,v,g,t):
         if (v is not None) and (value(m.FixedCommitment[g,t]) is not None):
             return v <= value(m.FixedCommitment[g,t])
         else:
             return True
-    model.FixedRegulation = Param(model.AGC_Generators, model.TimePeriods, initialize=TimeMapper(agc_gen_attrs.get('fixed_regulation')),
+    model.FixedRegulation = Param(model.AGC_Generators, model.TimePeriods, initialize=TimeMapper(agc_gen_attrs.get('fixed_regulation', dict())),
                                     default=None, within=model.FixedCommitmentTypes, validate=validate_fixed_reg)
 
     def zonal_up_bounds(m, rz, t):
@@ -507,8 +508,8 @@ def regulation_services(model, zone_initializer_builder, zone_requirement_getter
     model.SystemRegulationDnShortfall = Var(model.TimePeriods, within=NonNegativeReals, bounds=system_dn_bounds)
     
     # regulation cost for
-    model.RegulationOfferFixedCost = Param(model.AGC_Generators, within=NonNegativeReals, default=0.0, initialize=agc_gen_attrs.get('agc_fixed_cost'))
-    model.RegulationOfferMarginalCost = Param(model.AGC_Generators, within=NonNegativeReals, default=0.0, initialize=agc_gen_attrs.get('agc_marginal_cost'))
+    model.RegulationOfferFixedCost = Param(model.AGC_Generators, within=NonNegativeReals, default=0.0, initialize=agc_gen_attrs.get('agc_fixed_cost', dict()))
+    model.RegulationOfferMarginalCost = Param(model.AGC_Generators, within=NonNegativeReals, default=0.0, initialize=agc_gen_attrs.get('agc_marginal_cost', dict()))
 
     if _is_relaxed(model):
         model.RegulationOn = Var(model.AGC_Generators, model.TimePeriods, within=UnitInterval)
@@ -616,13 +617,13 @@ def spinning_reserves(model, zone_initializer_builder, zone_requirement_getter, 
     # limit,  cost of spinning reserves
     # NOTE: This is here in case the user wants to limit this beyond the ramping limits
     model.SpinningReserveCapability = Param(model.ThermalGenerators, within=NonNegativeReals, default=float('inf'),
-                                                initialize=thermal_gen_attrs.get('spinning_capacity'))
-    model.SpinningReservePrice = Param(model.ThermalGenerators, within=NonNegativeReals, default=0.0, initialize=thermal_gen_attrs.get('spinning_cost'))
+                                                initialize=thermal_gen_attrs.get('spinning_capacity', dict()))
+    model.SpinningReservePrice = Param(model.ThermalGenerators, within=NonNegativeReals, default=0.0, initialize=thermal_gen_attrs.get('spinning_cost', dict()))
     
     # spinning reserve requirements
     model.ZonalSpinningReserveRequirement = Param(model.SpinningReserveZones, model.TimePeriods, within=NonNegativeReals,
                                                         initialize=zone_requirement_getter('spinning_reserve_requirement'))
-    model.SystemSpinningReserveRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('spinning_reserve_requirement')))
+    model.SystemSpinningReserveRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('spinning_reserve_requirement', dict())))
 
     def zonal_spin_bounds(m,rz,t):
         return (0, m.ZonalSpinningReserveRequirement[rz,t])
@@ -715,12 +716,12 @@ def non_spinning_reserves(model, zone_initializer_builder, zone_requirement_gett
         return v <= value(m.MaximumPowerOutput[g])
     model.NonSpinningReserveCapability = Param(model.NonSpinGenerators, within=NonNegativeReals, default=0.0, validate=validate_nonspin_bid,
                                                     initialize=nspin_gen_attrs['non_spinning_capacity'])
-    model.NonSpinningReservePrice = Param(model.NonSpinGenerators, within=NonNegativeReals, default=0.0, initialize=nspin_gen_attrs.get('non_spinning_cost'))
+    model.NonSpinningReservePrice = Param(model.NonSpinGenerators, within=NonNegativeReals, default=0.0, initialize=nspin_gen_attrs.get('non_spinning_cost', dict()))
     
     model.ZonalNonSpinningReserveRequirement = Param(model.NonSpinReserveZones, model.TimePeriods, within=NonNegativeReals, default=0.0,
                                                         initialize=zone_requirement_getter('non_spinning_reserve_requirement'))
     model.SystemNonSpinningReserveRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, 
-                                                        initialize=TimeMapper(system.get('non_spinning_reserve_requirement')))
+                                                        initialize=TimeMapper(system.get('non_spinning_reserve_requirement', dict())))
 
     def zonal_fast_bounds(m,rz,t):
         return (0, m.ZonalNonSpinningReserveRequirement[rz,t])
@@ -814,13 +815,13 @@ def supplemental_reserves(model, zone_initializer_builder, zone_requirement_gett
     def validate_nonspin_bid(m,v,g):
         return v <= value(m.MaximumPowerOutput[g])
     model.SupplementalReserveCapabilityNonSpin = Param(model.SupplementalNonSpinGenerators, within=NonNegativeReals, default=0.0, 
-                                                        validate=validate_nonspin_bid, initialize=supplemental_nspin_gen_attrs.get('supplemental_non_spinning_capacity'))
+                                                        validate=validate_nonspin_bid, initialize=supplemental_nspin_gen_attrs.get('supplemental_non_spinning_capacity', dict()))
 
     ## NOTE: this param is here if the user wants to limit this beyond the nominal ramping limits
     model.SupplementalReserveCapabilitySpin = Param(model.ThermalGenerators, within=NonNegativeReals, default=float('inf'),
-                                                        initialize=thermal_gen_attrs.get('supplemental_spinning_capacity'))
+                                                        initialize=thermal_gen_attrs.get('supplemental_spinning_capacity', dict()))
 
-    model.SupplementalReservePrice = Param(model.ThermalGenerators, within=NonNegativeReals, default=0.0, initialize=thermal_gen_attrs.get('supplemental_cost'))
+    model.SupplementalReservePrice = Param(model.ThermalGenerators, within=NonNegativeReals, default=0.0, initialize=thermal_gen_attrs.get('supplemental_cost', dict()))
     model.SupplementalReserveMinutes = Param(within=PositiveReals, default=30.)
 
     # Supplemental reserve requirement
@@ -828,7 +829,7 @@ def supplemental_reserves(model, zone_initializer_builder, zone_requirement_gett
     model.ZonalSupplementalReserveRequirement = Param(model.SupplementalReserveZones, model.TimePeriods, within=NonNegativeReals, default=0.0,
                                                         initialize=zone_requirement_getter('supplemental_reserve_requirement'))
     model.SystemSupplementalReserveRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, 
-                                                        initialize=TimeMapper(system.get('supplemental_reserve_requirement')))
+                                                        initialize=TimeMapper(system.get('supplemental_reserve_requirement', dict())))
 
     def zonal_op_bounds(m,rz,t):
         return (0, m.ZonalSupplementalReserveRequirement[rz,t])
@@ -948,8 +949,8 @@ def flexible_ramping_reserves(model, zone_initializer_builder, zone_requirement_
     model.ZonalFlexDnRequirement = Param(model.FlexRampZones, model.TimePeriods, within=NonNegativeReals, default=0.0,
                                             initialize=zone_requirement_getter('flexible_ramp_down_requirement'))
 
-    model.SystemFlexUpRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('flexible_ramp_up_requirement')))
-    model.SystemFlexDnRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('flexible_ramp_down_requirement')))
+    model.SystemFlexUpRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('flexible_ramp_up_requirement', dict())))
+    model.SystemFlexDnRequirement = Param(model.TimePeriods, within=NonNegativeReals, default=0.0, initialize=TimeMapper(system.get('flexible_ramp_down_requirement', dict())))
 
     def zonal_flex_up_bounds(m, rz, t):
         return (0, m.ZonalFlexUpRequirement[rz,t])

--- a/egret/model_library/unit_commitment/tests/test_uc_utils.py
+++ b/egret/model_library/unit_commitment/tests/test_uc_utils.py
@@ -1,0 +1,45 @@
+#  ___________________________________________________________________________
+#
+#  EGRET: Electrical Grid Research and Engineering Tools
+#  Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+#  (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+#  Government retains certain rights in this software.
+#  This software is distributed under the Revised BSD License.
+#  ___________________________________________________________________________
+
+import pytest
+
+from egret.data.model_data import ModelData
+from egret.data.tests.test_model_data import testdata
+from egret.model_library.unit_commitment.uc_utils import uc_time_helper
+
+## these should be arbitary to mimic 
+## a pyomo RangeSet
+TimePeriods = [3,4,5]
+
+time_mapper = uc_time_helper(TimePeriods)
+
+md_testdata = ModelData(testdata)
+load_attrs = md_testdata.attributes(element_type='load')
+
+def test_None():
+    assert time_mapper(None) == dict()
+
+def test_empty_dict():
+    assert time_mapper(dict()) == dict()
+
+def test_single_item_mapping():
+    expected_result = { 3:11.0, 4:111.0, 5:111.1 }
+    assert time_mapper(load_attrs['Pl']['L1']) == expected_result
+
+def test_single_item_expansion():
+    expected_result = { 3:11.0, 4:11.0, 5:11.0 }
+    assert time_mapper(load_attrs['Ql']['L1']) == expected_result
+
+def test_multi_item_mapping():
+    expected_result = { ('L1', 3):11.0, ('L1', 4):111.0, ('L1',5):111.1 }
+    assert time_mapper(load_attrs['Pl']) == expected_result
+
+def test_multi_item_expansion():
+    expected_result = { ('L1',3):11.0, ('L1',4):11.0, ('L1',5):11.0 }
+    assert time_mapper(load_attrs['Ql']) == expected_result

--- a/egret/model_library/unit_commitment/uc_utils.py
+++ b/egret/model_library/unit_commitment/uc_utils.py
@@ -41,31 +41,39 @@ def add_model_attr(attr, requires = {}):
 ## provides a view on grid_data attributes that
 ## is handy for building pyomo params
 ## Assums the last key is time
-def uc_time_helper(_data):
-    ## if there is no data,
-    ## we return None to the initializer
-    if _data is None:
-        return None
-    def init_rule(m, *key):
-        ## last key is time
-        pm_t = key[-1]
-        key = key[:-1]
-        if len(key) == 0:
-            return get_time_attr(_data, pm_t)
-        if len(key) == 1:
-            key = key[0]
-        if key in _data:
-            return get_time_attr(_data[key], pm_t)
-        else:
-            return None
+def uc_time_helper(model_time_periods):
+    TimePeriods = list(model_time_periods)
 
-    def get_time_attr(att, pm_t):
-        if isinstance(att, dict):
-            if 'data_type' in att and att['data_type'] == 'time_series':
-                return att['values'][pm_t-1]
-            else:
-                raise Exception("Unexpected dictionary {}".format(att))
+    def dict_constructor(_data):
+        return_dict = dict()
+        ## if there is no data,
+        ## we return dict() to the initializer
+        if _data is None or _data == dict():
+            return return_dict
+        ## if the _data is a non-empty dictionary,
+        ## then either this "thing" is itself indexed,
+        ## or it is a time series for one thing
+        if isinstance(_data,dict):
+            ## in this case, this is a time series of one "thing"
+            if 'data_type' in _data and _data['data_type'] == 'time_series':
+                values = _data['values']
+                for i,t in enumerate(TimePeriods):
+                    return_dict[t] = values[i]
+            else: ## it's a dictionary of things, which are potentially time indexed
+                for key, att in _data.items():
+                    if isinstance(att, dict):
+                        if 'data_type' in att and att['data_type'] == 'time_series':
+                            values = att['values']
+                            for i,t in enumerate(TimePeriods):
+                                return_dict[key,t] = values[i]
+                        else:
+                            raise Exception("Unexpected dictionary {}".format(att))
+                    else:
+                        for t in TimePeriods:
+                            return_dict[key,t] = att
         else:
-            return att
+            for t in TimePeriods:
+                return_dict[t] = _data
+        return return_dict
 
-    return init_rule
+    return dict_constructor


### PR DESCRIPTION
This PR makes changes to the way the unit commitment models use the `initialize` keyword argument of pyomo Param. Due to upstream changes in pyomo, the way it is currently held is no longer valid against pyomo master.

Specifically, the current behavior of Egret returns `None` when a value is not provided, which had caused pyomo to fall back on value provide by the `default` keyword arugment. Due to Pyomo/pyomo#1272, now values returned by the initializer function not in the domain cause pyomo to raise an exception.

The proposed behavior in the PR always gives a `dict` to the `initialize` argument of Param. Further, the way each dictionary is constructed preserves the sparsity for Params which are often at their default value.