### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The COIN-OR organization - who developers CBC - also provides pre-built binaries
 
 ### Testing the Installation
 
-To test the functionality of the unit commitment aspects of EGRET, execute the following command from the EGRET models/test sub-directory:
+To test the functionality of the unit commitment aspects of EGRET, execute the following command from the EGRET models/tests sub-directory:
 
    pytest test_unit_commitment.py
 


### PR DESCRIPTION
Fixing a typo in a directory name - "models/tests" instead of "models/test".