### PR TITLE
Changing default to relaxed=False for all UC model generators

### DIFF
--- a/egret/models/tests/test_unit_commitment.py
+++ b/egret/models/tests/test_unit_commitment.py
@@ -145,6 +145,8 @@ def test_CA_uc_model():
     lp_obj_list = [4185855.30972, 5423650.80043, 5965411.93718, 5439434.94733, 6029118.03019]
     _test_uc_model(create_CA_unit_commitment_model, relax=True, test_objvals=lp_obj_list)
 
+# This test sometimes times out Travis, so skip if using cbc or glpk
+@unittest.skipUnless(comm_mip_avail, "Neither Gurobi or CPLEX solver is available")
 def test_CHP_uc_model():
     lp_obj_list = [4195062.031337061, 5441117.29937132, 5989325.835633724, 5454266.5169105325, 6055624.773215021]
     _test_uc_model(create_CHP_unit_commitment_model, relax=True, test_objvals=lp_obj_list)

--- a/egret/models/unit_commitment.py
+++ b/egret/models/unit_commitment.py
@@ -550,7 +550,7 @@ def create_CA_unit_commitment_model(model_data,
 
 def create_CHP_unit_commitment_model(model_data,
                                      network_constraints='ptdf_power_flow',
-                                     relaxed=True,
+                                     relaxed=False,
                                      **kwargs):
     '''
     Create a new unit commitment model based on the "extensive form" convex hull
@@ -604,7 +604,7 @@ def create_CHP_unit_commitment_model(model_data,
 
 def create_super_tight_unit_commitment_model(model_data,
                                              network_constraints='ptdf_power_flow',
-                                             relaxed=True,
+                                             relaxed=False,
                                              **kwargs):
     '''
     Create a new unit commitment formulation based using the tightest formulation available


### PR DESCRIPTION
`create_CHP_unit_commitment_model` and `create_super_tight_unit_commitment_model` inadvertently create relaxed models by default. This PR changes both to create integer restricted models by default, which is the norm for every other `create_*_unit_commitment_model` in this file.

Because Travis/CBC sometimes have issue with `test_CHP_uc_model`, this also marks that test to only run if `comm_mip_avail`.