### PR TITLE
Adding a hook so a user can specify an in-memory PTDF matrix when creating a unit commitment model

### DIFF
--- a/egret/data/ptdf_utils.py
+++ b/egret/data/ptdf_utils.py
@@ -124,6 +124,7 @@ class PTDFMatrix(object):
         self._set_lazy_limits(ptdf_options)
 
     def _calculate(self):
+        logger.info("Calculating PTDF Matrix")
         self._calculate_ptdf()
         self._calculate_phi_adjust()
         self._calculate_phase_shift()
@@ -326,6 +327,7 @@ class PTDFMatrix(object):
 class PTDFLossesMatrix(PTDFMatrix):
 
     def _calculate(self):
+        logger.info("Calculating PTDF Matrix")
         self._calculate_ptdf()
         self._calculate_phi_adjust()
         self._calculate_phi_loss_constant()

--- a/egret/model_library/unit_commitment/power_balance.py
+++ b/egret/model_library/unit_commitment/power_balance.py
@@ -158,6 +158,7 @@ def _ptdf_dcopf_network_model(block,tm):
     _setup_interface_slacks(m,block,tm)
 
     ### Get the PTDF matrix from cache, from file, or create a new one
+    ### m._PTDFs set in uc_model_generator
     if branches_out_service not in m._PTDFs:
         buses_idx = tuple(buses.keys())
 
@@ -624,9 +625,6 @@ def copperplate_relaxed_power_flow(model, slacks=True):
                                             'storage_service': None,
                                             })
 def ptdf_power_flow(model, slacks=True):
-    ## allow for this to already exist
-    if not hasattr(model, '_PTDFs'):
-        model._PTDFs = dict()
     _add_egret_power_flow(model, _ptdf_dcopf_network_model, reactive_power=False, slacks=slacks)
 
 @add_model_attr(component_name, requires = {'data_loader': None,

--- a/egret/model_library/unit_commitment/uc_model_generator.py
+++ b/egret/model_library/unit_commitment/uc_model_generator.py
@@ -37,7 +37,7 @@ UCFormulation = namedtuple('UCFormulation',
                              ]
                             )
 
-def generate_model( model_data, uc_formulation, relax_binaries=False, ptdf_options=None ):
+def generate_model( model_data, uc_formulation, relax_binaries=False, ptdf_options=None, PTDF_matrix_dict=None ):
     """
     returns a UC uc_formulation as an abstract model with the 
     components specified in a UCFormulation, with the option
@@ -53,6 +53,10 @@ def generate_model( model_data, uc_formulation, relax_binaries=False, ptdf_optio
         Default is False.
     ptdf_options : dict, optional
         Dictionary of options for ptdf transmission model
+    PTDF_matrix_dict : dict, optional
+        Dictionary of egret.data.ptdf_utils.PTDFMatrix objects for use in model construction.
+        WARNING: Nearly zero checking is done on the consistency of this object with the
+                 model_data. Use with extreme caution!
 
     Returns
     -------
@@ -62,7 +66,7 @@ def generate_model( model_data, uc_formulation, relax_binaries=False, ptdf_optio
 
     md = model_data.clone_in_service()
     scale_ModelData_to_pu(md, inplace=True)
-    return _generate_model( md, *_get_formulation_from_UCFormulation( uc_formulation ), relax_binaries , ptdf_options )
+    return _generate_model( md, *_get_formulation_from_UCFormulation( uc_formulation ), relax_binaries , ptdf_options, PTDF_matrix_dict )
 
 def _generate_model( model_data,
                     _status_vars,
@@ -79,6 +83,7 @@ def _generate_model( model_data,
                     _objective, 
                     _relax_binaries = False,
                     _ptdf_options = None,
+                    _PTDF_matrix_dict = None,
                     ):
     
     model = pe.ConcreteModel()
@@ -97,6 +102,11 @@ def _generate_model( model_data,
         lpu.check_and_scale_ptdf_options(_ptdf_options, baseMVA)
 
         model._ptdf_options = _ptdf_options
+
+        if _PTDF_matrix_dict is not None:
+            model._PTDFs = _PTDF_matrix_dict
+        else:
+            model._PTDFs = {}
 
     ## enforece time 1 ramp rates
     model.enforce_t1_ramp_rates = True


### PR DESCRIPTION
In support of: https://github.com/grid-parity-exchange/Prescient/issues/28