### PR TITLE
Updating requirements to Pyomo 5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ EGRET is available under the BSD License (see LICENSE.txt)
 
 ### Requirements
 
-* Pyomo version 5.6 or later
+* Pyomo version 5.7 or later
 * pytest
 * Optimization solvers for Pyomo - specific requirements depends on the models being solved. EGRET is tested with Gurobi or CPLEX for MIP-based problems (e.g., unit commitment) and Ipopt (with HSL linear solvers) for NLP problems.
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools_kwargs = {
     'install_requires': [],
     'scripts': [],
     'include_package_data': True,
-    'install_requires' : ['pyomo>=5.6', 'numpy', 'pytest', 'pandas', 'matplotlib', 'seaborn']
+    'install_requires' : ['pyomo>=5.7', 'numpy', 'pytest', 'pandas', 'matplotlib', 'seaborn']
 }
 
 setup(name=DISTNAME,


### PR DESCRIPTION
This change would make Pyomo 5.7 or later a requirement for EGRET.

Pyomo versions less than 5.7 have issues processing LinearExpressions in some cases (see https://github.com/Pyomo/pyomo/pull/1403, https://github.com/Pyomo/pyomo/pull/1405). The Prescient regression tests fail with #143 and Pyomo<5.7, so unless we revert #143 this is already a soft requirement. And it goes without saying that LinearExpressions were used in limited places before #143, hence making this change prudent regardless of #143.