### PR TITLE
OPF slack bounds

### DIFF
--- a/egret/model_library/transmission/tx_utils.py
+++ b/egret/model_library/transmission/tx_utils.py
@@ -174,6 +174,38 @@ def gens_by_bus(buses, gens):
 
     return gens_by_bus
 
+def over_gen_limit(load, gens, gen_maxs):
+    '''
+    Calculates the maximum amount of over-generation
+    given a load and set of generators with
+    associated maximum outputs
+    '''
+    max_over_gen = 0.
+    if load < 0.:
+        max_over_gen += -load
+    for g in gens:
+        g_max = gen_maxs[g]
+        if g_max > 0:
+            max_over_gen += g_max
+
+    return max_over_gen
+
+def load_shed_limit(load, gens, gen_mins):
+    '''
+    Calculates the maximum amount of load shedding
+    given a load and set of generators with
+    associated minimum outputs
+    '''
+    max_load_shed = 0.
+    if load > 0.:
+        max_load_shed += load
+    for g in gens:
+        g_min = gen_mins[g]
+        if g_min < 0:
+            max_load_shed += -g_min
+
+    return max_load_shed
+
 ## attributes which are scaled for power flow models
 ancillary_service_stack = [
                             'reserve_requirement',

--- a/egret/model_library/unit_commitment/power_balance.py
+++ b/egret/model_library/unit_commitment/power_balance.py
@@ -410,7 +410,7 @@ def _add_load_mismatch(model):
                 if p_max > 0:
                     max_injections += p_max
                 if p_min < 0:
-                    max_withdrawls += -pmin
+                    max_withdrawls += -p_min
 
             for n in model.NondispatchableGeneratorsAtBus[b]:
                 p_max = value(model.MaxNondispatchablePower[n,t])

--- a/egret/models/acopf.py
+++ b/egret/models/acopf.py
@@ -27,28 +27,28 @@ from collections import OrderedDict
 
 
 def _include_feasibility_slack(model, bus_names, bus_p_loads, bus_q_loads,
-                               gens_by_bus, gens_attrs,
+                               gens_by_bus, gen_attrs,
                                p_marginal_slack_penalty, q_marginal_slack_penalty):
     
     import egret.model_library.decl as decl
 
     p_over_gen_bounds = {k: (0, tx_utils.over_gen_limit(bus_p_loads[k], gens_by_bus[k], gen_attrs['p_max'])) for k in bus_names}
-    decl.declare_var('p_over_generation', model=model, index_set=bus_attrs['names'],
+    decl.declare_var('p_over_generation', model=model, index_set=bus_names,
                      initialize=0., bounds=p_over_gen_bounds
                      )
 
     p_load_shed_bounds  = {k: (0, tx_utils.load_shed_limit(bus_p_loads[k], gens_by_bus[k], gen_attrs['p_min'])) for k in bus_names}
-    decl.declare_var('p_load_shed', model=model, index_set=bus_attrs['names'],
+    decl.declare_var('p_load_shed', model=model, index_set=bus_names,
                      initialize=0., bounds=p_load_shed_bounds
                      )
 
     q_over_gen_bounds = {k: (0, tx_utils.over_gen_limit(bus_q_loads[k], gens_by_bus[k], gen_attrs['q_max'])) for k in bus_names}
-    decl.declare_var('q_over_generation', model=model, index_set=bus_attrs['names'],
+    decl.declare_var('q_over_generation', model=model, index_set=bus_names,
                      initialize=0., bounds=q_over_gen_bounds
                      )
 
     q_load_shed_bounds  = {k: (0, tx_utils.load_shed_limit(bus_q_loads[k], gens_by_bus[k], gen_attrs['q_min'])) for k in bus_names}
-    decl.declare_var('q_load_shed', model=model, index_set=bus_attrs['names'],
+    decl.declare_var('q_load_shed', model=model, index_set=bus_names,
                      initialize=0., bounds=q_load_shed_bounds
                      )
 
@@ -57,7 +57,7 @@ def _include_feasibility_slack(model, bus_names, bus_p_loads, bus_q_loads,
 
     penalty_expr = sum(p_marginal_slack_penalty * (model.p_over_generation[bus_name] + model.p_load_shed[bus_name])
                      + q_marginal_slack_penalty * (model.q_over_generation[bus_name] + model.q_load_shed[bus_name])
-                    for bus_name in bus_attrs['names'])
+                    for bus_name in bus_names)
     return p_rhs_kwargs, q_rhs_kwargs, penalty_expr
 
 def _validate_and_extract_slack_penalties(model_data):

--- a/egret/models/acopf.py
+++ b/egret/models/acopf.py
@@ -26,25 +26,32 @@ from math import pi, radians
 from collections import OrderedDict
 
 
-def _include_feasibility_slack(model, bus_attrs, gen_attrs, bus_p_loads, bus_q_loads,
+def _include_feasibility_slack(model, bus_names, bus_p_loads, bus_q_loads,
+                               gens_by_bus, gens_attrs,
                                p_marginal_slack_penalty, q_marginal_slack_penalty):
     
     import egret.model_library.decl as decl
-    slack_init = {k: 0 for k in bus_attrs['names']}
-    slack_bounds = {k: (0, sum(bus_p_loads.values())) for k in bus_attrs['names']}
+
+    p_over_gen_bounds = {k: (0, tx_utils.over_gen_limit(bus_p_loads[k], gens_by_bus[k], gen_attrs['p_max'])) for k in bus_names}
     decl.declare_var('p_over_generation', model=model, index_set=bus_attrs['names'],
-                     initialize=slack_init, bounds=slack_bounds
+                     initialize=0., bounds=p_over_gen_bounds
                      )
+
+    p_load_shed_bounds  = {k: (0, tx_utils.load_shed_limit(bus_p_loads[k], gens_by_bus[k], gen_attrs['p_min'])) for k in bus_names}
     decl.declare_var('p_load_shed', model=model, index_set=bus_attrs['names'],
-                     initialize=slack_init, bounds=slack_bounds
+                     initialize=0., bounds=p_load_shed_bounds
                      )
-    slack_bounds = {k: (0, sum(bus_q_loads.values())) for k in bus_attrs['names']}
+
+    q_over_gen_bounds = {k: (0, tx_utils.over_gen_limit(bus_q_loads[k], gens_by_bus[k], gen_attrs['q_max'])) for k in bus_names}
     decl.declare_var('q_over_generation', model=model, index_set=bus_attrs['names'],
-                     initialize=slack_init, bounds=slack_bounds
+                     initialize=0., bounds=q_over_gen_bounds
                      )
+
+    q_load_shed_bounds  = {k: (0, tx_utils.load_shed_limit(bus_q_loads[k], gens_by_bus[k], gen_attrs['q_min'])) for k in bus_names}
     decl.declare_var('q_load_shed', model=model, index_set=bus_attrs['names'],
-                     initialize=slack_init, bounds=slack_bounds
+                     initialize=0., bounds=q_load_shed_bounds
                      )
+
     p_rhs_kwargs = {'include_feasibility_slack_pos':'p_over_generation','include_feasibility_slack_neg':'p_load_shed'}
     q_rhs_kwargs = {'include_feasibility_slack_pos':'q_over_generation','include_feasibility_slack_neg':'q_load_shed'}
 
@@ -105,8 +112,9 @@ def _create_base_power_ac_model(model_data, include_feasibility_slack=False):
     q_rhs_kwargs = {}
     if include_feasibility_slack:
         p_marginal_slack_penalty, q_marginal_slack_penalty = _validate_and_extract_slack_penalties(md)
-        p_rhs_kwargs, q_rhs_kwargs, penalty_expr = _include_feasibility_slack(model, bus_attrs, gen_attrs,
+        p_rhs_kwargs, q_rhs_kwargs, penalty_expr = _include_feasibility_slack(model, bus_attrs['names'],
                                                                               bus_p_loads, bus_q_loads,
+                                                                              gens_by_bus, gen_attrs,
                                                                               p_marginal_slack_penalty,
                                                                               q_marginal_slack_penalty)
 
@@ -372,10 +380,11 @@ def create_riv_acopf_model(model_data, include_feasibility_slack=False):
     q_rhs_kwargs = {}
     if include_feasibility_slack:
         p_marginal_slack_penalty, q_marginal_slack_penalty = _validate_and_extract_slack_penalties(md)
-        p_rhs_kwargs, q_rhs_kwargs, penalty_expr = _include_feasibility_slack(model, bus_attrs, gen_attrs,
+        p_rhs_kwargs, q_rhs_kwargs, penalty_expr = _include_feasibility_slack(model, bus_attrs['names'],
                                                                               bus_p_loads, bus_q_loads,
+                                                                              gens_by_bus, gen_attrs,
                                                                               p_marginal_slack_penalty,
-                                                                              q_marginal_slack_penalty)        
+                                                                              q_marginal_slack_penalty)
 
     ### fix the reference bus
     ref_bus = md.data['system']['reference_bus']

--- a/egret/models/copperplate_dispatch.py
+++ b/egret/models/copperplate_dispatch.py
@@ -34,7 +34,7 @@ def _include_system_feasibility_slack(model, bus_p_loads, gen_attrs, p_marginal_
 
     load_shed_bounds = (0, tx_utils.load_shed_limit(load, gen_attrs['names'], gen_attrs['p_min']))
     decl.declare_var('p_load_shed', model=model, index_set=None,
-                     initialize=0., bounds=slack_bounds
+                     initialize=0., bounds=load_shed_bounds
                      )
 
     p_rhs_kwargs = {'include_feasibility_slack_pos':'p_over_generation','include_feasibility_slack_neg':'p_load_shed'}

--- a/egret/models/dcopf.py
+++ b/egret/models/dcopf.py
@@ -31,17 +31,19 @@ from egret.common.log import logger
 from math import pi, radians
 
 
-def _include_feasibility_slack(model, bus_attrs, gen_attrs, bus_p_loads, p_marginal_slack_penalty):
+def _include_feasibility_slack(model, bus_names, bus_p_loads, gens_by_bus, gen_attrs, p_marginal_slack_penalty):
     import egret.model_library.decl as decl
-    slack_init = {k: 0 for k in bus_attrs['names']}
 
-    slack_bounds = {k: (0, sum(bus_p_loads.values())) for k in bus_attrs['names']}
+    over_gen_bounds = {k: (0, tx_utils.over_gen_limit(bus_p_loads[k], gens_by_bus[k], gen_attrs['p_max'])) for k in bus_names}
     decl.declare_var('p_over_generation', model=model, index_set=bus_attrs['names'],
-                     initialize=slack_init, bounds=slack_bounds
+                     initialize=0., bounds=over_gen_bounds
                      )
+
+    load_shed_bounds  = {k: (0, tx_utils.load_shed_limit(bus_p_loads[k], gens_by_bus[k], gen_attrs['p_min'])) for k in bus_names}
     decl.declare_var('p_load_shed', model=model, index_set=bus_attrs['names'],
-                     initialize=slack_init, bounds=slack_bounds
+                     initialize=0., bounds=load_shed_bounds
                      )
+
     p_rhs_kwargs = {'include_feasibility_slack_pos':'p_over_generation','include_feasibility_slack_neg':'p_load_shed'}
 
     penalty_expr = sum(p_marginal_slack_penalty * (model.p_over_generation[bus_name] + model.p_load_shed[bus_name])
@@ -88,8 +90,8 @@ def create_btheta_dcopf_model(model_data, include_angle_diff_limits=False, inclu
     penalty_expr = None
     if include_feasibility_slack:
         p_marginal_slack_penalty = _validate_and_extract_slack_penalty(md)        
-        p_rhs_kwargs, penalty_expr = _include_feasibility_slack(model, bus_attrs, gen_attrs,
-                                                                bus_p_loads, p_marginal_slack_penalty)
+        p_rhs_kwargs, penalty_expr = _include_feasibility_slack(model, bus_attrs['names'], bus_p_loads,
+                                                                gens_by_bus, gen_attrs, p_marginal_slack_penalty)
 
     ### fix the reference bus
     ref_bus = md.data['system']['reference_bus']
@@ -226,7 +228,7 @@ def create_ptdf_dcopf_model(model_data, include_feasibility_slack=False, base_po
     p_rhs_kwargs = {}
     if include_feasibility_slack:
         p_marginal_slack_penalty = _validate_and_extract_slack_penalty(md)                
-        p_rhs_kwargs, penalty_expr = _include_system_feasibility_slack(model, gen_attrs, bus_p_loads, p_marginal_slack_penalty)
+        p_rhs_kwargs, penalty_expr = _include_system_feasibility_slack(model, bus_p_loads, gen_attrs, p_marginal_slack_penalty)
 
     ### declare the p balance
     libbus.declare_eq_p_balance_ed(model=model,

--- a/egret/models/dcopf.py
+++ b/egret/models/dcopf.py
@@ -35,19 +35,19 @@ def _include_feasibility_slack(model, bus_names, bus_p_loads, gens_by_bus, gen_a
     import egret.model_library.decl as decl
 
     over_gen_bounds = {k: (0, tx_utils.over_gen_limit(bus_p_loads[k], gens_by_bus[k], gen_attrs['p_max'])) for k in bus_names}
-    decl.declare_var('p_over_generation', model=model, index_set=bus_attrs['names'],
+    decl.declare_var('p_over_generation', model=model, index_set=bus_names,
                      initialize=0., bounds=over_gen_bounds
                      )
 
     load_shed_bounds  = {k: (0, tx_utils.load_shed_limit(bus_p_loads[k], gens_by_bus[k], gen_attrs['p_min'])) for k in bus_names}
-    decl.declare_var('p_load_shed', model=model, index_set=bus_attrs['names'],
+    decl.declare_var('p_load_shed', model=model, index_set=bus_names,
                      initialize=0., bounds=load_shed_bounds
                      )
 
     p_rhs_kwargs = {'include_feasibility_slack_pos':'p_over_generation','include_feasibility_slack_neg':'p_load_shed'}
 
     penalty_expr = sum(p_marginal_slack_penalty * (model.p_over_generation[bus_name] + model.p_load_shed[bus_name])
-                    for bus_name in bus_attrs['names'])
+                    for bus_name in bus_names)
     return p_rhs_kwargs, penalty_expr
 
 def create_btheta_dcopf_model(model_data, include_angle_diff_limits=False, include_feasibility_slack=False):

--- a/egret/models/dcopf_losses.py
+++ b/egret/models/dcopf_losses.py
@@ -80,7 +80,8 @@ def create_btheta_losses_dcopf_model(model_data, relaxation_type=RelaxationType.
     penalty_expr = None
     if include_feasibility_slack:
         p_marginal_slack_penalty = _validate_and_extract_slack_penalty(md)                
-        p_rhs_kwargs, penalty_expr = _include_feasibility_slack(model, bus_attrs, gen_attrs, bus_p_loads, p_marginal_slack_penalty)
+        p_rhs_kwargs, penalty_expr = _include_feasibility_slack(model, bus_attrs['names'], bus_p_loads,
+                                                                gens_by_bus, gen_attrs, p_marginal_slack_penalty)
 
     ### fix the reference bus
     ref_bus = md.data['system']['reference_bus']
@@ -233,7 +234,7 @@ def create_ptdf_losses_dcopf_model(model_data, include_feasibility_slack=False, 
     p_rhs_kwargs = {}
     if include_feasibility_slack:
         p_marginal_slack_penalty = _validate_and_extract_slack_penalty(md)
-        p_rhs_kwargs, penalty_expr = _include_system_feasibility_slack(model, gen_attrs, bus_p_loads, p_marginal_slack_penalty)
+        p_rhs_kwargs, penalty_expr = _include_system_feasibility_slack(model, bus_p_loads, gen_attrs, p_marginal_slack_penalty)
 
     ### declare net withdraw expression for use in PTDF power flows
     libbus.declare_expr_p_net_withdraw_at_bus(model=model,


### PR DESCRIPTION
Would close #164. The computed slack bounds are similar to those in the [unit commitment code](https://github.com/grid-parity-exchange/Egret/blob/bd2fe978016eddb2f87db93b2ae5012e50bf6600/egret/model_library/unit_commitment/power_balance.py#L383).

@DLWoodruff, would you mind trying this out?

Is 0 the right value to initialize all these slacks to?