### PR TITLE
Lazy slacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ EGRET is available under the BSD License (see LICENSE.txt)
 
 ### Requirements
 
-* Pyomo version 5.7 or later
+* Pyomo version 5.7.1 or later
 * pytest
 * Optimization solvers for Pyomo - specific requirements depends on the models being solved. EGRET is tested with Gurobi or CPLEX for MIP-based problems (e.g., unit commitment) and Ipopt (with HSL linear solvers) for NLP problems.
 

--- a/egret/common/lazy_ptdf_utils.py
+++ b/egret/common/lazy_ptdf_utils.py
@@ -12,7 +12,7 @@ from pyomo.solvers.plugins.solvers.persistent_solver import PersistentSolver
 from egret.model_library.defn import ApproximationType
 from egret.common.log import logger
 import egret.model_library.transmission.branch as libbranch
-import pyomo.environ as pe
+import pyomo.environ as pyo
 import numpy as np
 import copy as cp
 
@@ -106,6 +106,13 @@ def add_monitored_flow_tracker(mb):
     mb._idx_monitored = list()
     mb._interfaces_monitored = list()
 
+    # add these if there are no slacks
+    # so we don't have to check later
+    # for these attributes
+    if not hasattr(mb, 'pf_slack_pos'):
+        mb.pf_slack_pos = pyo.Var([], dense=False)
+    if not hasattr(mb, 'pfi_slack_neg'):
+        mb.pfi_slack_pos = pyo.Var([], dense=False)
 
 def _get_viol_viol_lazy(limit_type, flow, lazy_limits, enforced_limits, mon_idx):
     assert limit_type in ['ub', 'lb']
@@ -256,7 +263,10 @@ def _generate_flow_monitor_remove_message(flow_type, bn, slack, baseMVA, time):
 
 ## flow constraint remover
 def remove_inactive(mb, solver, time=None, prepend_str=""):
-    model = mb.model()
+    if time is None: # DCOPF
+        model = mb
+    else: # UC
+        model = mb.parent_block()
     PTDF = mb._PTDF
     ptdf_options = model._ptdf_options
     baseMVA = model.model_data.data['system']['baseMVA']
@@ -266,7 +276,7 @@ def remove_inactive(mb, solver, time=None, prepend_str=""):
     persistent_solver = isinstance(solver, PersistentSolver)
 
     if persistent_solver:
-        _load_pf_slacks(solver, mb.model(), [time])
+        _load_pf_slacks(solver, model, [time])
 
     ## get the lines we're monitoring
     idx_monitored = mb._idx_monitored
@@ -398,7 +408,7 @@ def _generate_flow_viol_warning(expr, e_type, bn, flow, limit, baseMVA, time):
     if time is not None:
         ret_str += " at time {}".format(time)
     ret_str += ", but flow exceeds limit!!\n\t flow={0}, limit={1}".format(flow*baseMVA, limit*baseMVA)
-    ret_str += ", model_flow={}".format(pe.value(expr[bn])*baseMVA)
+    ret_str += ", model_flow={}".format(pyo.value(expr[bn])*baseMVA)
     return ret_str
 
 def _generate_flow_monitor_message(e_type, bn, flow=None, lower_limit=None, upper_limit=None, baseMVA=None, time=None):
@@ -427,17 +437,17 @@ def _iter_over_int_viol_set(int_viol_set, mb, PTDF, abs_ptdf_tol, rel_ptdf_tol):
             mb.pfi[i_n] = expr
         yield i, i_n
 
-def _generate_branch_thermal_bounds(mb, bn, thermal_limit, slacks):
-    m = mb.model()
-    if slacks and bn in m.BranchesWithSlack and \
-            bn not in mb.pf_slack_branchname_to_index:
-        ## ^^ could have been added and removed
-        neg_slack = mb.pf_slack_neg.add()
-        pos_slack = mb.pf_slack_pos.add()
-        # VarList is 1-indexed
-        mb.pf_slack_branchname_to_index[bn] = len(mb.pf_slack_neg)
-        assert len(mb.pf_slack_pos) == len(mb.pf_slack_neg)
-        new_var = True
+def _generate_branch_thermal_bounds(mb, bn, thermal_limit):
+    if bn in mb.pf_slack_pos.index_set():
+        if bn not in mb.pf_slack_pos:
+            neg_slack = mb.pf_slack_neg[bn]
+            pos_slack = mb.pf_slack_pos[bn]
+            assert len(mb.pf_slack_pos) == len(mb.pf_slack_neg)
+            new_var = True
+        else: # the constraint could have been added and removed
+            neg_slack = mb.pf_slack_neg[bn]
+            pos_slack = mb.pf_slack_pos[bn]
+            new_var = False
     else:
         neg_slack = None
         pos_slack = None
@@ -445,17 +455,17 @@ def _generate_branch_thermal_bounds(mb, bn, thermal_limit, slacks):
 
     return libbranch.generate_thermal_bounds(mb.pf[bn], -thermal_limit, thermal_limit, neg_slack, pos_slack), new_var
 
-def _generate_interface_bounds(mb, i_n, minimum_limit, maximum_limit, slacks):
-    m = mb.model()
-    if slacks and i_n in m.InterfacesWithSlack and \
-            i_n not in mb.pfi_slack_interfacename_to_index:
-        ## ^^ could have been added and removed
-        neg_slack = mb.pfi_slack_neg.add()
-        pos_slack = mb.pfi_slack_pos.add()
-        # VarList is 1-indexed
-        mb.pfi_slack_interfacename_to_index[i_n] = len(mb.pfi_slack_neg)
-        assert len(mb.pfi_slack_pos) == len(mb.pfi_slack_neg)
-        new_var = True
+def _generate_interface_bounds(mb, i_n, minimum_limit, maximum_limit):
+    if i_n in mb.pfi_slack_pos.index_set():
+        if i_n not in mb.pfi_slack_pos:
+            neg_slack = mb.pfi_slack_neg[i_n]
+            pos_slack = mb.pfi_slack_pos[i_n]
+            assert len(mb.pfi_slack_pos) == len(mb.pfi_slack_neg)
+            new_var = True
+        else: # the constraint could have been added and removed
+            neg_slack = mb.pfi_slack_neg[i_n]
+            pos_slack = mb.pfi_slack_pos[i_n]
+            new_var = False
     else:
         neg_slack = None
         pos_slack = None
@@ -467,7 +477,10 @@ def _generate_interface_bounds(mb, i_n, minimum_limit, maximum_limit, slacks):
 def add_violations(viol_lazy, int_viol_lazy, PFV, PFV_I, mb, md, solver, ptdf_options,
                     PTDF, time=None, prepend_str=""):
 
-    model = mb.model()
+    if time is None:
+        model = mb
+    else:
+        model = mb.parent_block()
 
     baseMVA = md.data['system']['baseMVA']
 
@@ -479,7 +492,6 @@ def add_violations(viol_lazy, int_viol_lazy, PFV, PFV_I, mb, md, solver, ptdf_op
 
     constr = mb.ineq_pf_branch_thermal_bounds
     viol_in_mb = mb._idx_monitored
-    slacks = hasattr(mb, 'pf_slack_branchname_to_index')
     for i, bn in _iter_over_viol_set(viol_lazy, mb, PTDF, abs_ptdf_tol, rel_ptdf_tol):
         thermal_limit = PTDF.branch_limits_array_masked[i]
         if PFV is None:
@@ -487,20 +499,21 @@ def add_violations(viol_lazy, int_viol_lazy, PFV, PFV_I, mb, md, solver, ptdf_op
         else:
             logger.debug(prepend_str+_generate_flow_monitor_message('branch', bn, PFV[i], -thermal_limit, thermal_limit, baseMVA, time))
 
-        constr[bn], new_slacks = _generate_branch_thermal_bounds(mb, bn, thermal_limit, slacks)
+        constr[bn], new_slacks = _generate_branch_thermal_bounds(mb, bn, thermal_limit)
         viol_in_mb.append(i)
         if new_slacks:
-            m = mb.model()
-            var_idx = mb.pf_slack_branchname_to_index[bn]
+            m = model
             obj_coef = m.TimePeriodLengthHours*m.BranchLimitPenalty[bn]
 
             if persistent_solver:
+                if m is not m.model():
+                    raise RuntimeError("Cannot add lazy var for branch slacks if part of a larger model")
                 ## update the objective through the add_column method
-                solver.add_column(m, mb.pf_slack_pos[var_idx], obj_coef, [], [])
-                solver.add_column(m, mb.pf_slack_neg[var_idx], obj_coef, [], [])
+                solver.add_column(m, mb.pf_slack_pos[bn], obj_coef, [], [])
+                solver.add_column(m, mb.pf_slack_neg[bn], obj_coef, [], [])
             else:
-                m.BranchViolationCost[time].expr += ( obj_coef*mb.pf_slack_pos[var_idx] + \
-                                                      obj_coef*mb.pf_slack_neg[var_idx] )
+                m.BranchViolationCost[time].expr += ( obj_coef*mb.pf_slack_pos[bn] + \
+                                                      obj_coef*mb.pf_slack_neg[bn] )
         if persistent_solver:
             solver.add_constraint(constr[bn])
 
@@ -509,7 +522,6 @@ def add_violations(viol_lazy, int_viol_lazy, PFV, PFV_I, mb, md, solver, ptdf_op
         return
     constr = mb.ineq_pf_interface_bounds
     int_viol_in_mb = mb._interfaces_monitored
-    slacks = hasattr(mb, 'pfi_slack_interfacename_to_index')
     for i, i_n in _iter_over_int_viol_set(int_viol_lazy, mb, PTDF, abs_ptdf_tol, rel_ptdf_tol):
         minimum_limit = PTDF.interface_min_limits[i]
         maximum_limit = PTDF.interface_max_limits[i]
@@ -517,20 +529,21 @@ def add_violations(viol_lazy, int_viol_lazy, PFV, PFV_I, mb, md, solver, ptdf_op
             logger.debug(prepend_str+_generate_flow_monitor_message('interface', i_n, time=time))
         else:
             logger.debug(prepend_str+_generate_flow_monitor_message('interface', i_n, PFV_I[i], minimum_limit, maximum_limit, baseMVA, time))
-        constr[i_n], new_slacks = _generate_interface_bounds(mb, i_n, minimum_limit, maximum_limit, slacks)
+        constr[i_n], new_slacks = _generate_interface_bounds(mb, i_n, minimum_limit, maximum_limit)
         int_viol_in_mb.append(i)
         if new_slacks:
-            m = mb.model()
-            var_idx = mb.pfi_slack_interfacename_to_index[i_n]
+            m = model
             obj_coef = m.TimePeriodLengthHours*m.InterfaceLimitPenalty[i_n]
 
             if persistent_solver:
+                if m is not m.model():
+                    raise RuntimeError("Cannot add lazy var for branch slacks if part of a larger model")
                 ## update the objective through the add_column method
-                solver.add_column(m, mb.pfi_slack_pos[var_idx], obj_coef, [], [])
-                solver.add_column(m, mb.pfi_slack_neg[var_idx], obj_coef, [], [])
+                solver.add_column(m, mb.pfi_slack_pos[i_n], obj_coef, [], [])
+                solver.add_column(m, mb.pfi_slack_neg[i_n], obj_coef, [], [])
             else:
-                m.InterfaceViolationCost[time].expr += (obj_coef*mb.pfi_slack_pos[var_idx] + \
-                                                        obj_coef*mb.pfi_slack_neg[var_idx] )
+                m.InterfaceViolationCost[time].expr += (obj_coef*mb.pfi_slack_pos[i_n] + \
+                                                        obj_coef*mb.pfi_slack_neg[i_n] )
         if persistent_solver:
             solver.add_constraint(constr[i_n])
 
@@ -554,11 +567,10 @@ def add_initial_monitored_branches(mb, branches, branches_in_service, ptdf_optio
 
     constr = mb.ineq_pf_branch_thermal_bounds
     viol_in_mb = mb._idx_monitored
-    slacks = hasattr(mb, 'pf_slack_branchname_to_index')
     for i, bn in _iter_over_initial_set(branches, branches_in_service, PTDF):
         thermal_limit = PTDF.branch_limits_array_masked[i]
         mb.pf[bn] = libbranch.get_power_flow_expr_ptdf_approx(mb, bn, PTDF, abs_ptdf_tol=abs_ptdf_tol, rel_ptdf_tol=rel_ptdf_tol)
-        constr[bn], _ = _generate_branch_thermal_bounds(mb, bn, thermal_limit, slacks)
+        constr[bn], _ = _generate_branch_thermal_bounds(mb, bn, thermal_limit)
         viol_in_mb.append(i)
 
 def _iter_over_initial_set_interfaces(interfaces, PTDF):
@@ -575,12 +587,11 @@ def add_initial_monitored_interfaces(mb, interfaces, ptdf_options, PTDF):
 
     constr = mb.ineq_pf_interface_bounds
     int_viol_in_mb = mb._interfaces_monitored
-    slacks = hasattr(mb, 'pfi_slack_interfacename_to_index')
     for i, i_n in _iter_over_initial_set_interfaces(interfaces, PTDF):
         minimum_limit = PTDF.interface_min_limits[i]
         maximum_limit = PTDF.interface_max_limits[i]
         mb.pfi[i_n] = libbranch.get_power_flow_interface_expr_ptdf(mb, i_n, PTDF, abs_ptdf_tol=abs_ptdf_tol, rel_ptdf_tol=rel_ptdf_tol)
-        constr[i_n], _ = _generate_interface_bounds(mb, i_n, minimum_limit, maximum_limit, slacks)
+        constr[i_n], _ = _generate_interface_bounds(mb, i_n, minimum_limit, maximum_limit)
         int_viol_in_mb.append(i)
 
 def copy_active_to_next_time(m, b_next, PTDF_next, slacks, slacks_I):
@@ -637,7 +648,7 @@ def _binary_var_generator(instance):
 def uc_instance_binary_relaxer(model, solver):
     persistent_solver = isinstance(solver, PersistentSolver)
     for ivar in _binary_var_generator(model):
-        ivar.domain = pe.UnitInterval
+        ivar.domain = pyo.UnitInterval
         if persistent_solver:
             for var in ivar.itervalues():
                 solver.update_var(var)
@@ -645,7 +656,7 @@ def uc_instance_binary_relaxer(model, solver):
 def uc_instance_binary_enforcer(model, solver):
     persistent_solver = isinstance(solver, PersistentSolver)
     for ivar in _binary_var_generator(model):
-        ivar.domain = pe.Binary
+        ivar.domain = pyo.Binary
         if persistent_solver:
             for var in ivar.itervalues():
                 solver.update_var(var)

--- a/egret/common/lazy_ptdf_utils.py
+++ b/egret/common/lazy_ptdf_utils.py
@@ -659,4 +659,7 @@ def _load_pf_slacks(solver, m, t_subset):
         vars_to_load.extend(b.pf_slack_neg.values())
         vars_to_load.extend(b.pfi_slack_pos.values())
         vars_to_load.extend(b.pfi_slack_neg.values())
-    solver.load_vars(vars_to_load)
+    # XpressPersistent raises an exception if
+    # this list is empty
+    if vars_to_load:
+        solver.load_vars(vars_to_load)

--- a/egret/model_library/transmission/branch.py
+++ b/egret/model_library/transmission/branch.py
@@ -816,18 +816,17 @@ def declare_ineq_p_branch_thermal_lbub(model, index_set,
 
     if approximation_type == ApproximationType.BTHETA or \
             approximation_type == ApproximationType.PTDF:
-        top_model = m.model()
         for branch_name in con_set:
             if p_thermal_limits[branch_name] is None:
                 continue
 
-            if slacks and branch_name in top_model.BranchesWithSlack:
-                neg_slack = m.pf_slack_neg.add()
-                pos_slack = m.pf_slack_pos.add()
-                # VarList is 1-indexed
-                m.pf_slack_branchname_to_index[branch_name] = len(m.pf_slack_neg)
-                slack_cost_expr.expr += (top_model.TimePeriodLengthHours*top_model.BranchLimitPenalty[branch_name] *
-                                    (neg_slack + pos_slack) )
+            if slacks and branch_name in m.pf_slack_neg.index_set():
+                assert branch_name in m.pf_slack_pos.index_set()
+                neg_slack = m.pf_slack_neg[branch_name]
+                pos_slack = m.pf_slack_pos[branch_name]
+                uc_model = slack_cost_expr.parent_block()
+                slack_cost_expr.expr += (uc_model.TimePeriodLengthHours*uc_model.BranchLimitPenalty[branch_name] *
+                                         (neg_slack + pos_slack) )
                 assert len(m.pf_slack_pos) == len(m.pf_slack_neg)
             else:
                 neg_slack = None
@@ -927,18 +926,17 @@ def declare_ineq_p_branch_thermal_bounds(model, index_set,
 
     if approximation_type == ApproximationType.BTHETA or \
             approximation_type == ApproximationType.PTDF:
-        top_model = m.model()
         for branch_name in con_set:
             limit = p_thermal_limits[branch_name]
             if limit is None:
                 continue
 
-            if slacks and branch_name in top_model.BranchesWithSlack:
-                neg_slack = m.pf_slack_neg.add()
-                pos_slack = m.pf_slack_pos.add()
-                # VarList is 1-indexed
-                m.pf_slack_branchname_to_index[branch_name] = len(m.pf_slack_neg)
-                slack_cost_expr.expr += (top_model.TimePeriodLengthHours*top_model.BranchLimitPenalty[branch_name] *
+            if slacks and branch_name in m.pf_slack_neg.index_set():
+                assert branch_name in m.pf_slack_pos.index_set()
+                neg_slack = m.pf_slack_neg[branch_name]
+                pos_slack = m.pf_slack_pos[branch_name]
+                uc_model = slack_cost_expr.parent_block()
+                slack_cost_expr.expr += (uc_model.TimePeriodLengthHours*uc_model.BranchLimitPenalty[branch_name] *
                                     (neg_slack + pos_slack) )
                 assert len(m.pf_slack_pos) == len(m.pf_slack_neg)
             else:
@@ -1031,19 +1029,18 @@ def declare_ineq_p_interface_bounds(model, index_set, interfaces,
 
     if approximation_type == ApproximationType.BTHETA or \
             approximation_type == ApproximationType.PTDF:
-        top_model = m.model()
         for interface_name in con_set:
             interface = interfaces[interface_name]
             if interface['minimum_limit'] is None and \
                     interface['maximum_limit'] is None:
                 continue
 
-            if slacks and interface_name in top_model.InterfacesWithSlack:
-                neg_slack = m.pfi_slack_neg.add()
-                pos_slack = m.pfi_slack_pos.add()
-                # VarList is 1-indexed
-                m.pfi_slack_interfacename_to_index[interface_name] = len(m.pfi_slack_neg)
-                slack_cost_expr.expr += (top_model.TimePeriodLengthHours*top_model.InterfaceLimitPenalty[interface_name] *
+            if slacks and interface_name in m.pfi_slack_neg.index_set():
+                assert interface_name in m.pfi_slack_pos.index_set()
+                neg_slack = m.pfi_slack_neg[interface_name]
+                pos_slack = m.pfi_slack_pos[interface_name]
+                uc_model = slack_cost_expr.parent_block()
+                slack_cost_expr.expr += (uc_model.TimePeriodLengthHours*uc_model.InterfaceLimitPenalty[interface_name] *
                                     (neg_slack + pos_slack) )
                 assert len(m.pfi_slack_pos) == len(m.pfi_slack_neg)
             else:

--- a/egret/model_library/transmission/tx_calc.py
+++ b/egret/model_library/transmission/tx_calc.py
@@ -634,9 +634,6 @@ def calculate_ptdf_factorization(branches,buses,index_set_branch,index_set_bus,r
     if not connected:
         raise RuntimeError("Network is not connected, cannot use PTDF formulation")
 
-    #(B_d A)
-    #J = _calculate_J11(branches,buses,index_set_branch,index_set_bus,mapping_bus_to_idx,base_point,approximation_type=ApproximationType.PTDF)
-
     #(A^T)
     At = calculate_adjacency_matrix_transpose(branches,index_set_branch,index_set_bus,mapping_bus_to_idx)
 

--- a/egret/model_library/transmission/tx_calc.py
+++ b/egret/model_library/transmission/tx_calc.py
@@ -325,6 +325,49 @@ def _calculate_J11(branches,buses,index_set_branch,index_set_bus,mapping_bus_to_
     J11 = sp.coo_matrix( (data, (row,col)), shape=(_len_branch, _len_bus))
     return J11.tocsc()
 
+def _calculate_Bd(branches,index_set_branch,base_point=BasePointType.FLATSTART,approximation_type=ApproximationType.PTDF):
+    """
+    Compute the power flow Jacobian for partial derivative of real power flow to voltage angle
+    """
+    _len_branch = len(index_set_branch)
+
+    data = []
+    row = []
+    col = []
+
+    for idx_row, branch_name in enumerate(index_set_branch):
+        branch = branches[branch_name]
+        from_bus = branch['from_bus']
+        to_bus = branch['to_bus']
+
+        tau = 1.0
+        if branch['branch_type'] == 'transformer':
+            tau = branch['transformer_tap_ratio']
+
+        if approximation_type == ApproximationType.PTDF:
+            x = branch['reactance']
+            b = -1/(tau*x)
+        elif approximation_type == ApproximationType.PTDF_LOSSES:
+            b = calculate_susceptance(branch)/tau
+
+        if base_point == BasePointType.FLATSTART:
+            val = b
+
+        elif base_point == BasePointType.SOLUTION: # TODO: check that we are loading the correct values (or results)
+            vn = buses[from_bus]['vm']
+            vm = buses[to_bus]['vm']
+            tn = buses[from_bus]['va']
+            tm = buses[to_bus]['va']
+
+            val = b * vn * vm * cos(tn - tm)
+
+        data.append(val)
+        row.append(idx_row)
+        col.append(idx_row)
+
+    Bd = sp.coo_matrix( (data, (row,col)), shape=(_len_branch, _len_branch))
+    return Bd.tocsc()
+
 
 def _calculate_L11(branches,buses,index_set_branch,index_set_bus,mapping_bus_to_idx,base_point=BasePointType.FLATSTART):
     """
@@ -593,9 +636,13 @@ def calculate_ptdf_factorization(branches,buses,index_set_branch,index_set_bus,r
         raise RuntimeError("Network is not connected, cannot use PTDF formulation")
 
     #(B_d A)
-    J = _calculate_J11(branches,buses,index_set_branch,index_set_bus,mapping_bus_to_idx,base_point,approximation_type=ApproximationType.PTDF)
+    #J = _calculate_J11(branches,buses,index_set_branch,index_set_bus,mapping_bus_to_idx,base_point,approximation_type=ApproximationType.PTDF)
+
     #(A^T)
     At = calculate_adjacency_matrix_transpose(branches,index_set_branch,index_set_bus,mapping_bus_to_idx)
+
+    Bd = _calculate_Bd(branches, index_set_branch)
+    J = Bd@(At.T)
 
     ref_bus_mask = np.ones(_len_bus, dtype=bool)
     ref_bus_mask[_ref_bus_idx] = False
@@ -611,13 +658,15 @@ def calculate_ptdf_factorization(branches,buses,index_set_branch,index_set_bus,r
     ## LU factorization
     MLU_MP = scipy.sparse.linalg.splu(M)
 
-    if interfaces is not None:
+    if interfaces is None:
+        return MLU_MP, B_dA, ref_bus_mask
+    else:
         if mapping_bus_to_idx is None:
             mapping_branch_to_idx = {branch_n: i for i, branch_n in enumerate(index_set_branch)}
         I = _calculate_interface_matrix(interfaces, index_set_interface, mapping_branch_to_idx)
         B_dA_I = I@B_dA
 
-    return MLU_MP, B_dA, ref_bus_mask, B_dA_I, I
+        return MLU_MP, B_dA, ref_bus_mask, B_dA_I, I
 
 def _calculate_interface_matrix(interfaces, index_set_interface, mapping_branch_to_idx):
     """

--- a/egret/model_library/unit_commitment/power_balance.py
+++ b/egret/model_library/unit_commitment/power_balance.py
@@ -31,7 +31,7 @@ from math import pi
 component_name = 'power_balance'
 
 def _setup_egret_network_model(block, tm):
-    m = block.model()
+    m = block.parent_block()
 
     ## this is not the "real" gens by bus, but the
     ## index of net injections from the UC model
@@ -542,7 +542,7 @@ def _add_hvdc(model):
 ## helper defining real power injection at a bus
 def _get_pg_expr_rule(t):
     def pg_expr_rule(block,b):
-        m = block.model()
+        m = block.parent_block()
         # bus b, time t (S)
         return sum(m.PowerGenerated[g, t] for g in m.ThermalGeneratorsAtBus[b]) \
                 + sum(m.PowerOutputStorage[s, t] for s in m.StorageAtBus[b])\
@@ -556,7 +556,7 @@ def _get_pg_expr_rule(t):
 ## helper defining reacative power injection at a bus
 def _get_qg_expr_rule(t):
     def qg_expr_rule(block,b):
-        m = block.model()
+        m = block.parent_block()
         # bus b, time t (S)
         return sum(m.ReactivePowerGenerated[g, t] for g in m.ThermalGeneratorsAtBus[b]) \
             + m.LoadGenerateMismatchReactive[b,t]

--- a/egret/model_library/unit_commitment/power_balance.py
+++ b/egret/model_library/unit_commitment/power_balance.py
@@ -82,18 +82,28 @@ def _setup_egret_network_topology(m,tm):
     return buses, branches, branches_in_service, branches_out_service, interfaces
 
 def _setup_branch_slacks(m,block,tm):
-    ### declare the branch slack variables
-    block.pf_slack_pos = VarList(domain=NonNegativeReals)
-    block.pf_slack_neg = VarList(domain=NonNegativeReals)
-
-    block.pf_slack_branchname_to_index = dict()
+    # declare the branch slack variables
+    # they have a sparse index set
+    libbranch.declare_var_pf_slack_pos(model=block,
+                                       index_set=m.BranchesWithSlack,
+                                       domain=NonNegativeReals,
+                                       dense=False)
+    libbranch.declare_var_pf_slack_neg(model=block,
+                                       index_set=m.BranchesWithSlack,
+                                       domain=NonNegativeReals,
+                                       dense=False)
 
 def _setup_interface_slacks(m,block,tm):
-    ### declare the interface slack variables
-    block.pfi_slack_pos = VarList(domain=NonNegativeReals)
-    block.pfi_slack_neg = VarList(domain=NonNegativeReals)
-
-    block.pfi_slack_interfacename_to_index = dict()
+    # declare the interface slack variables
+    # they have a sparse index set
+    libbranch.declare_var_pfi_slack_pos(model=block,
+                                        index_set=m.InterfacesWithSlack,
+                                        domain=NonNegativeReals,
+                                        dense=False)
+    libbranch.declare_var_pfi_slack_neg(model=block,
+                                        index_set=m.InterfacesWithSlack,
+                                        domain=NonNegativeReals,
+                                        dense=False)
 
 def _ptdf_dcopf_network_model(block,tm):
     m, gens_by_bus, bus_p_loads, bus_gs_fixed_shunts = \

--- a/egret/model_library/unit_commitment/thermal_convex_hull.py
+++ b/egret/model_library/unit_commitment/thermal_convex_hull.py
@@ -98,8 +98,8 @@ def ramping_polytope_block_rule(rp, g):
     '''
 
     ## assume the generator parameters
-    ## live on the main model
-    model = rp.model() 
+    ## live on the parent block
+    model = rp.parent_block()
     value = pe.value
     quicksum = pe.quicksum
 

--- a/egret/models/unit_commitment.py
+++ b/egret/models/unit_commitment.py
@@ -1174,9 +1174,8 @@ def _save_uc_results(m, relaxed):
             if l in m.BranchesWithSlack:
                 pf_violation_dict = _preallocated_list(data_time_periods)
                 for dt, (mt, b) in enumerate(m.TransmissionBlock.items()):
-                    if l in b.pf_slack_branchname_to_index:
-                        var_idx = b.pf_slack_branchname_to_index[l]
-                        pf_violation_dict[dt] = value(b.pf_slack_pos[var_idx] - b.pf_slack_neg[var_idx])
+                    if l in b.pf_slack_pos:
+                        pf_violation_dict[dt] = value(b.pf_slack_pos[l] - b.pf_slack_neg[l])
                     else:
                         pf_violation_dict[dt] = 0.
                 l_dict['pf_violation'] = _time_series_dict(pf_violation_dict)
@@ -1206,9 +1205,8 @@ def _save_uc_results(m, relaxed):
             if i in m.InterfacesWithSlack:
                 pf_violation_dict = _preallocated_list(data_time_periods)
                 for dt, (mt, b) in enumerate(m.TransmissionBlock.items()):
-                    if i in b.pfi_slack_interfacename_to_index:
-                        var_idx = b.pfi_slack_interfacename_to_index[i]
-                        pf_violation_dict[dt] = value(b.pfi_slack_pos[var_idx] - b.pfi_slack_neg[var_idx])
+                    if i in b.pfi_slack_pos:
+                        pf_violation_dict[dt] = value(b.pfi_slack_pos[i] - b.pfi_slack_neg[i])
                     else:
                         pf_violation_dict[dt] = 0.
                 i_dict['pf_violation'] = _time_series_dict(pf_violation_dict)
@@ -1260,9 +1258,8 @@ def _save_uc_results(m, relaxed):
             if i in m.InterfacesWithSlack:
                 pf_violation_dict = _preallocated_list(data_time_periods)
                 for dt, (mt, b) in enumerate(m.TransmissionBlock.items()):
-                    if i in b.pfi_slack_interfacename_to_index:
-                        var_idx = b.pfi_slack_interfacename_to_index[i]
-                        pf_violation_dict[dt] = value(b.pfi_slack_pos[var_idx] - b.pfi_slack_neg[var_idx])
+                    if i in b.pfi_slack_pos:
+                        pf_violation_dict[dt] = value(b.pfi_slack_pos[i] - b.pfi_slack_neg[i])
                     else:
                         pf_violation_dict[dt] = 0.
                 i_dict['pf_violation'] = _time_series_dict(pf_violation_dict)
@@ -1276,9 +1273,8 @@ def _save_uc_results(m, relaxed):
             if l in m.BranchesWithSlack:
                 pf_violation_dict = _preallocated_list(data_time_periods)
                 for dt, (mt, b) in enumerate(m.TransmissionBlock.items()):
-                    if l in b.pf_slack_branchname_to_index:
-                        var_idx = b.pf_slack_branchname_to_index[l]
-                        pf_violation_dict[dt] = value(b.pf_slack_pos[var_idx] - b.pf_slack_neg[var_idx])
+                    if l in b.pf_slack_pos:
+                        pf_violation_dict[dt] = value(b.pf_slack_pos[l] - b.pf_slack_neg[l])
                     else:
                         pf_violation_dict[dt] = 0.
                 l_dict['pf_violation'] = _time_series_dict(pf_violation_dict)

--- a/egret/models/unit_commitment.py
+++ b/egret/models/unit_commitment.py
@@ -722,7 +722,7 @@ def _lazy_ptdf_uc_solve_loop(m, md, solver, timelimit, solver_tee=True, symbolic
         Use symbolic solver labels when writing to the solver (default is False)
     iteration_limit : int (optional)
         Number of iterations before a hard termination (default is 100000)
-    var_to_load : None, list (optional)
+    vars_to_load : None, list (optional)
         Applies only to persistent solvers. If None, every primal variable is loaded.
         If a list, then should be a list of pyomo Vars to be loaded into the pyomo model
         at termination. Default is None.
@@ -805,6 +805,8 @@ def _lazy_ptdf_uc_solve_loop(m, md, solver, timelimit, solver_tee=True, symbolic
 
         if terminate_this_iter and not add_all_lazy_violations:
             if warmstart_loop:
+                if persistent_solver:
+                    lpu._load_pf_slacks(solver, m, t_subset)
                 _lazy_ptdf_warmstart_copy_violations(m, md, time_periods, solver, ptdf_options, prepend_str)
                 results = _lazy_ptdf_solve(m, solver, persistent_solver, symbolic_solver_labels, solver_tee, vars_to_load, solve_method_options)
             if persistent_solver and duals and (results is not None) and (vars_to_load is None):
@@ -832,6 +834,8 @@ def _lazy_ptdf_uc_solve_loop(m, md, solver, timelimit, solver_tee=True, symbolic
     else:
         logger.warning(prepend_str+'WARNING: Exiting on maximum iterations for lazy PTDF model. Result is not transmission feasible.')
         if warmstart_loop:
+            if persistent_solver:
+                lpu._load_pf_slacks(solver, m, t_subset)
             _lazy_ptdf_warmstart_copy_violations(m, md, time_periods, solver, ptdf_options)
             results = _lazy_ptdf_solve(m, solver, persistent_solver, symbolic_solver_labels, solver_tee, vars_to_load, solve_method_options)
         if persistent_solver and duals and (results is not None) and (vars_to_load is None):
@@ -859,16 +863,8 @@ def _outer_lazy_ptdf_solve_loop(m, solver, mipgap, timelimit, solver_tee, symbol
             b = m.TransmissionBlock[t]
             if isinstance(b.p_nw, pe.Var):
                 vars_to_load.extend(b.p_nw.values())
-                vars_to_load.extend(b.pfi_slack_neg.values())
-                vars_to_load.extend(b.pfi_slack_pos.values())
-                vars_to_load.extend(b.pf_slack_neg.values())
-                vars_to_load.extend(b.pf_slack_pos.values())
                 if t in t_subset:
                     vars_to_load_t_subset.extend(b.p_nw.values())
-                    vars_to_load_t_subset.extend(b.pfi_slack_neg.values())
-                    vars_to_load_t_subset.extend(b.pfi_slack_pos.values())
-                    vars_to_load_t_subset.extend(b.pf_slack_neg.values())
-                    vars_to_load_t_subset.extend(b.pf_slack_pos.values())
             else:
                 vars_to_load = None
                 vars_to_load_t_subset = None
@@ -1168,8 +1164,12 @@ def _save_uc_results(m, relaxed):
             l_dict['pf'] = _time_series_dict(pf_dict)
             if l in m.BranchesWithSlack:
                 pf_violation_dict = _preallocated_list(data_time_periods)
-                for dt, mt in enumerate(m.TimePeriods):
-                    pf_violation_dict[dt] = value(m.TransmissionBlock[mt].pf_slack_pos[l] - m.TransmissionBlock[mt].pf_slack_neg[l])
+                for dt, (mt, b) in enumerate(m.TransmissionBlock.items()):
+                    if l in b.pf_slack_branchname_to_index:
+                        var_idx = b.pf_slack_branchname_to_index[l]
+                        pf_violation_dict[dt] = value(b.pf_slack_pos[var_idx] - b.pf_slack_neg[var_idx])
+                    else:
+                        pf_violation_dict[dt] = 0.
                 l_dict['pf_violation'] = _time_series_dict(pf_violation_dict)
 
         for b,b_dict in buses.items():
@@ -1196,8 +1196,12 @@ def _save_uc_results(m, relaxed):
             i_dict['pf'] = _time_series_dict(pf_dict)
             if i in m.InterfacesWithSlack:
                 pf_violation_dict = _preallocated_list(data_time_periods)
-                for dt, mt in enumerate(m.TimePeriods):
-                    pf_violation_dict[dt] = value(m.TransmissionBlock[mt].pfi_slack_pos[i] - m.TransmissionBlock[mt].pfi_slack_neg[i])
+                for dt, (mt, b) in enumerate(m.TransmissionBlock.items()):
+                    if i in b.pfi_slack_interfacename_to_index:
+                        var_idx = b.pfi_slack_interfacename_to_index[i]
+                        pf_violation_dict[dt] = value(b.pfi_slack_pos[var_idx] - b.pfi_slack_neg[var_idx])
+                    else:
+                        pf_violation_dict[dt] = 0.
                 i_dict['pf_violation'] = _time_series_dict(pf_violation_dict)
 
         for k,k_dict in dc_branches.items():
@@ -1246,8 +1250,12 @@ def _save_uc_results(m, relaxed):
             i_dict['pf'] = _time_series_dict(pf_dict)
             if i in m.InterfacesWithSlack:
                 pf_violation_dict = _preallocated_list(data_time_periods)
-                for dt, mt in enumerate(m.TimePeriods):
-                    pf_violation_dict[dt] = value(m.TransmissionBlock[mt].pfi_slack_pos[i] - m.TransmissionBlock[mt].pfi_slack_neg[i])
+                for dt, (mt, b) in enumerate(m.TransmissionBlock.items()):
+                    if i in b.pfi_slack_interfacename_to_index:
+                        var_idx = b.pfi_slack_interfacename_to_index[i]
+                        pf_violation_dict[dt] = value(b.pfi_slack_pos[var_idx] - b.pfi_slack_neg[var_idx])
+                    else:
+                        pf_violation_dict[dt] = 0.
                 i_dict['pf_violation'] = _time_series_dict(pf_violation_dict)
 
         for l,l_dict in branches.items():
@@ -1258,8 +1266,12 @@ def _save_uc_results(m, relaxed):
             l_dict['pf'] = _time_series_dict(pf_dict)
             if l in m.BranchesWithSlack:
                 pf_violation_dict = _preallocated_list(data_time_periods)
-                for dt, mt in enumerate(m.TimePeriods):
-                    pf_violation_dict[dt] = value(m.TransmissionBlock[mt].pf_slack_pos[l] - m.TransmissionBlock[mt].pf_slack_neg[l])
+                for dt, (mt, b) in enumerate(m.TransmissionBlock.items()):
+                    if l in b.pf_slack_branchname_to_index:
+                        var_idx = b.pf_slack_branchname_to_index[l]
+                        pf_violation_dict[dt] = value(b.pf_slack_pos[var_idx] - b.pf_slack_neg[var_idx])
+                    else:
+                        pf_violation_dict[dt] = 0.
                 l_dict['pf_violation'] = _time_series_dict(pf_violation_dict)
 
         for b,b_dict in buses.items():

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools_kwargs = {
     'install_requires': [],
     'scripts': [],
     'include_package_data': True,
-    'install_requires' : ['pyomo>=5.7', 'numpy', 'pytest', 'pandas', 'matplotlib', 'seaborn']
+    'install_requires' : ['pyomo>=5.7.1', 'numpy', 'pytest', 'pandas', 'matplotlib', 'seaborn']
 }
 
 setup(name=DISTNAME,


### PR DESCRIPTION
This PR makes two changes in anticipation of resolving #149.
1. For lazy constraints, slacks are now generated on-the-fly based on the `add_column` method for `PersistentSolver` (Pyomo/pyomo#1568). The current approach is okay for O(|L|) constraints (creating all slack variables up front), but something different will be needed for O(|L|^2) constraints. This change makes EGRET dependent on Pyomo 5.7.1+.
1. Minor clean-up in tx_calc for separate A, B_d matrices
1. Closes #182 

Limitations:
1. If the unit commitment problem is part of a larger block, and a persistent solver is used, the current implementation of lazy PTDF will raise a `RuntimeError`. I think this is manageable for the time being.
