### PR TITLE
Properly propogating the QuickStart attribute for prescient dat files

### DIFF
--- a/egret/model_library/unit_commitment/params.py
+++ b/egret/model_library/unit_commitment/params.py
@@ -301,7 +301,7 @@ def load_params(model, model_data):
     
     model.VerifyThermalGeneratorBuses = BuildAction(model.ThermalGenerators, rule=verify_thermal_generator_buses_rule)
     
-    model.QuickStart = Param(model.ThermalGenerators, within=Boolean, default=False, initialize=thermal_gen_attrs.get('quickstart_capable', dict()))
+    model.QuickStart = Param(model.ThermalGenerators, within=Boolean, default=False, initialize=thermal_gen_attrs.get('fast_start', dict()))
     
     def init_quick_start_generators(m):
         return [g for g in m.ThermalGenerators if value(m.QuickStart[g]) == 1]

--- a/egret/parsers/prescient_dat_parser.py
+++ b/egret/parsers/prescient_dat_parser.py
@@ -126,7 +126,7 @@ def create_model_data_dict_params(params, keep_names=False):
         g_d = { 'generator_type':'thermal', }
         g_d['bus'] = gen_bus_dict[g]
         g_d['fuel'] = params.ThermalGeneratorType[g]
-        g_d['fast_start'] = params.QuickStart[g]
+        g_d['fast_start'] = (g in params.QuickStartGenerators)
         g_d['fixed_commitment'] = (1 if params.MustRun[g] else None)
         g_d['in_service'] = True
         g_d['zone'] = params.ReserveZoneLocation[g]
@@ -383,6 +383,10 @@ def setup_abstract_model(model):
     model.VerifyThermalGeneratorBuses = BuildAction(model.ThermalGenerators, rule=verify_thermal_generator_buses_rule)
     
     model.QuickStart = Param(model.ThermalGenerators, within=Boolean, default=False)
+
+    def init_quick_start_generators(m):
+        return [g for g in m.ThermalGenerators if value(m.QuickStart[g]) == 1]
+    model.QuickStartGenerators = Set(within=model.ThermalGenerators, initialize=init_quick_start_generators)
     
     # optionally force a unit to be on.
     model.MustRun = Param(model.ThermalGenerators, within=Boolean, default=False)

--- a/egret/viz/generate_graphs.py
+++ b/egret/viz/generate_graphs.py
@@ -181,7 +181,7 @@ def generate_stack_graph(egret_model_data, bar_width=0.9,
                 if not sum(pg_array) > 0.0:
                     continue
 
-                is_quickstart = generator_data.get('quickstart_capable', False)
+                is_quickstart = generator_data.get('fast_start', False)
 
                 if is_quickstart:
                     quickstart_label = 'quickstart'


### PR DESCRIPTION
For certain *.dat files, like those included with mpi-sppy, the "QuickStart" attribute was not properly carried through from dat file to Egret ModelData object to Pyomo unit commitment model.

This PR makes some minor changes to the prescient_dat_parser and the unit commitment parameter loader. Note that `quickstart_capable` is not used anywhere else -- but `fast_start` gets used for unit which can provide 10-minute reserve. `supplemental_start` is used for units which can provide 30-minute reserve.