### PR TITLE
Refactoring _lazy_ptdf_uc_solve_loop into component functions

### DIFF
--- a/.github/workflows/prescient.yml
+++ b/.github/workflows/prescient.yml
@@ -56,8 +56,9 @@ jobs:
           - name: Install Prescient
             run: |
               cd ..
-              git clone https://github.com/grid-parity-exchange/Prescient.git
+              git clone --depth=1 https://github.com/grid-parity-exchange/Prescient.git
               cd Prescient
+              conda env update --name test_env --file environment.yml
               python setup.py develop
           - name: Run Prescient Tests
             run: |


### PR DESCRIPTION
This PR simply refactors the 100-line function which controls a lazy-ptdf pass to call several new functions for its main components to make the existing functionality more modular.

Bigger question: there's now ~300 lines of lazy PTDF logic in unit_commitment.py that should probably be in its own file, and probably be further refactored. There's also the function `_lazy_ptdf_dcopf_solve_loop` in dcopf.py and the files `egret/common/lazy_ptdf_utils.py` and the file `egret/data/ptdf_utils.py`. 
Should we organize Egret's PTDF functionality into its own (top-level) directory?

Also makes some unrelated changes to the Prescient CI tests because Prescient's dependencies are not currently reliably installed via pip https://github.com/grid-parity-exchange/Prescient/pull/92.