### PR TITLE
adding missing __init__ file

### DIFF
--- a/egret/parsers/rts_gmlc/__init__.py
+++ b/egret/parsers/rts_gmlc/__init__.py
@@ -1,0 +1,9 @@
+#  ___________________________________________________________________________
+#
+#  EGRET: Electrical Grid Research and Engineering Tools
+#  Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
+#  (NTESS). Under the terms of Contract DE-NA0003525 with NTESS, the U.S.
+#  Government retains certain rights in this software.
+#  This software is distributed under the Revised BSD License.
+#  ___________________________________________________________________________
+


### PR DESCRIPTION
PR #209 was missing an `__init__.py` file in the new directory it added. This PR adds an empty `__init__.py` file to address that.