### PR TITLE
Filter scalar reserve requirements

### DIFF
--- a/egret/parsers/rts_gmlc/_reserves.py
+++ b/egret/parsers/rts_gmlc/_reserves.py
@@ -9,6 +9,8 @@
 
 from __future__ import annotations
 
+from typing import NamedTuple, Optional, Sequence
+
 reserve_name_map = {
     'Spin_Up': 'spinning_reserve_requirement',
     'Reg_Up': 'regulation_up_requirement',
@@ -25,3 +27,38 @@ def is_valid_reserve_name(name:str, model_dict:dict=None):
     res, area = name.split('_R', 1)
     return (res in reserve_name_map) and \
            ((model_dict is None) or (area in model_dict['elements']['area']))
+
+class ScalarReserveValue(NamedTuple):
+    ''' A reserve type, scope, and scalar value.
+
+    If area_name is None, this is a global reserve value.
+    '''
+    reserve_type: str
+    area_name: Optional[str]
+    value: float
+
+class ScalarReserveData():
+    ''' Scalar reserve values that should only be applied to one type of model.
+    '''
+    def __init__(self, 
+                 da_scalars: Sequence[ScalarReserveValue], 
+                 rt_scalars: Sequence[ScalarReserveValue]):
+        self._da_scalars = da_scalars
+        self._rt_scalars = rt_scalars
+
+    @property
+    def da_scalars(self) -> Sequence[ScalarReserveValue]:
+        ''' Scalar reserve values that only apply to DAY_AHEAD models
+        '''
+        return self._da_scalars
+
+    @property
+    def rt_scalars(self) -> Sequence[ScalarReserveValue]:
+        ''' Scalar reserve values that only apply to REAL_TIME models
+        '''
+        return self._rt_scalars
+
+    def get_simulation_reserves(self, simulation_type:str) -> Sequence[ScalarReserveValue]:
+        ''' Get scalar reserve values that only apply the requested simulation type
+        '''
+        return self._rt_scalars if simulation_type == 'REAL_TIME' else self._da_scalars


### PR DESCRIPTION
Use the Reserve_Products row of simulation_objects.csv to decide which scalar reserve products to included in a model.

Note that this only applies to scalar reserve requirements (the ones listed in reserves.csv). It does not filter timeseries by reserve type; if a timeseries is listed in timeseries_pointers.csv for a given reserve, the timeseries is included in the model
even if the reserve type isn't listed in simulation_objects.csv.

If simulation_objects.csv does not have a Reserve_Products row then all scalar reserve products are accepted for both DAY_AHEAD and REAL_TIME models.

To summarize:
* If a reserve product has a timeseries for the relevant simulation type, the timeseries will be included.
* If a reserve product does not have a timeseries but does have a row in reserves.csv, the reserve will be specified with a scalar value if one of the following is true:
    * The reserve product is listed in simulation_objects.csv in the Reserve_Products row under the relevant simulation type, OR
    * There is no ReserveProducts row in simulation_objects.csv.
