### PR TITLE
Eliminating Pyomo 6 deprecation warning

### DIFF
--- a/egret/common/lazy_ptdf_utils.py
+++ b/egret/common/lazy_ptdf_utils.py
@@ -818,16 +818,16 @@ def uc_instance_binary_relaxer(model, solver):
     for ivar in _binary_var_generator(model):
         ivar.domain = pyo.UnitInterval
         if persistent_solver:
-            for var in ivar.itervalues():
-                solver.update_var(var)
+            for k in ivar:
+                solver.update_var(ivar[k])
 
 def uc_instance_binary_enforcer(model, solver):
     persistent_solver = isinstance(solver, PersistentSolver)
     for ivar in _binary_var_generator(model):
         ivar.domain = pyo.Binary
         if persistent_solver:
-            for var in ivar.itervalues():
-                solver.update_var(var)
+            for k in ivar:
+                solver.update_var(ivar[k])
 
 def _load_pf_slacks(solver, m, t_subset):
     ## ensure the slack variables are loaded


### PR DESCRIPTION
`IndexedComponent.itervalues()` was deprecated in Pyomo 6; this PR eliminates calls to it from Egret. I believe this implementation should have the same performance on older versions of Pyomo, while bypassing creating an itermediate list like the `value` method does in older (and current) versions of Pyomo.

One incongruity I caught in current Pyomo: the `keys()`, `values()`, and `items()` methods on `IndexedComponent` document returning an _iterator_, but instead return a _list_.