### PR TITLE
ModelData Utilities 

### DIFF
--- a/egret/model_library/transmission/tests/test_tx_utils.py
+++ b/egret/model_library/transmission/tests/test_tx_utils.py
@@ -457,3 +457,10 @@ class TestValidateCostCurves(unittest.TestCase):
                                                                     p_max=85,
                                                                     gen_name='foo',
                                                                     t=None)
+
+class TestTxUtils(unittest.TestCase):
+
+    def test_element_types(self):
+        etypes = list(tx_utils.element_types())
+        self.assertNotEqual(len(etypes), 0)
+        self.assertEqual(len(etypes), len(set(etypes)))

--- a/egret/model_library/transmission/tx_utils.py
+++ b/egret/model_library/transmission/tx_utils.py
@@ -370,6 +370,8 @@ scaled_attributes = {
                                                     'pl',
                                                     'ql',
                                                  ],
+                       ('element_type', 'security_constraint', None) : [
+                                                                       ],
                        ('element_type', 'security_constraint', 'pg') : [ 'lower_bound',
                                                                          'upper_bound',
                                                                          'violation_penalty',
@@ -381,6 +383,10 @@ scaled_attributes = {
                                                                  'pf',
                                                                  'pf_violation',
                                                                ],
+                       ('element_type', 'fuel_supply', None) : [
+                                                               ],
+                       ('element_type', 'interchange', None) : [
+                                                               ],
                        ('system_attributes', None, None ) : [
                                                         'load_mismatch_cost',
                                                         'q_load_mismatch_cost',
@@ -389,6 +395,11 @@ scaled_attributes = {
                                                      ancillary_service_stack,
                    }
 
+def element_types():
+    ''' Get an iterable that yields each valid egret element type as a string
+    '''
+    return (key[1] for key in scaled_attributes.keys()
+            if key[0] == 'element_type' and key[2] is None)
 
 def scale_ModelData_to_pu(model_data, inplace=False):
     return _convert_modeldata_pu(model_data, _divide_by_baseMVA, inplace)


### PR DESCRIPTION
## Summary/Motivation:
These utilities are useful for Prescient when working with ModelData objects, and may be useful to others as well.

## Changes proposed in this PR:
Added two utilities that help you work with ModelData objects:
  -  `egret.model_library.transmission.tx_utils.element_types()` - Returns an iterable that lists all valid types you can pass to ModelData.elements('type-name')
   - `egret.parsers.rts_gmlc.parser.ParsedCache.get_timeseries_locations(ModelData)` - Returns an iterable that enumerates all the places in the passed-in ModelData object that holds a time series, as specified in the RTS-GMLC data that was parsed and cached in the ParsedCache object.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
