### PR TITLE
Reducing complexity of check that all thermal generators are assigned…

### DIFF
--- a/.github/workflows/prescient.yml
+++ b/.github/workflows/prescient.yml
@@ -49,9 +49,18 @@ jobs:
               fi
               # test cbc executable
               cbc -quit
+          - name: Install Nose/Parameterized/Pytest
+            run: |
+              pip install nose parameterized pytest coveralls
+          - name: Install Cython/Numpy/Pandas
+            run: |
+              pip install cython numpy pandas
           - name: Install Pyomo
             run: |
               pip install git+https://github.com/Pyomo/pyomo.git@${{ matrix.pyomo-version }}
+          - name: Install Coramin
+            run: |
+              pip install coramin
           - name: Install EGRET
             run: |
               python setup.py develop

--- a/egret/model_library/unit_commitment/params.py
+++ b/egret/model_library/unit_commitment/params.py
@@ -342,14 +342,15 @@ def load_params(model, model_data, slack_type):
     
     model.ThermalGeneratorType = Param(model.ThermalGenerators, within=Any, default='C', initialize=thermal_gen_attrs.get('fuel', dict()))
     
-    def verify_thermal_generator_buses_rule(m, g):
-       for b in m.Buses:
-          if g in m.ThermalGeneratorsAtBus[b]:
-             return 
-       print("DATA ERROR: No bus assigned for thermal generator=%s" % g)
-       assert(False)
+    def verify_thermal_generators_assigned_to_buses_rule(m):
+       generators_at_buses = set(g for b in m.Buses for g in m.ThermalGeneratorsAtBus[b])
+       all_generators = set(m.ThermalGenerators)
+       unassigned_generators = all_generators.difference(generators_at_buses)
+       if len(unassigned_generators) > 0:
+           print("Encountered thermal generators unassigned to a bus: "+str(unassigned_generators))
+       assert(len(unassigned_generators)==0)
     
-    model.VerifyThermalGeneratorBuses = BuildAction(model.ThermalGenerators, rule=verify_thermal_generator_buses_rule)
+    model.VerifyThermalGeneratorsAssignedToBuses = BuildAction(rule=verify_thermal_generators_assigned_to_buses_rule)
     
     model.QuickStart = Param(model.ThermalGenerators, within=Boolean, default=False, initialize=thermal_gen_attrs.get('fast_start', dict()))
     


### PR DESCRIPTION
… to a bus - makes a big difference in model construction time when buses and generators grow into the thousands.

## Fixes # .
- Performance issue when checking that all thermal generators are assigned to a bus. Was an order |G|*|B| operation.

## Summary/Motivation:
- Resolves performance issue identified when constructing large-scale (synthetic ERCOT) UC cases.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
