### PR TITLE
Fix DataFrame indexing error in RTS-GMLC parser

### DIFF
--- a/egret/parsers/rts_gmlc/parsed_cache.py
+++ b/egret/parsers/rts_gmlc/parsed_cache.py
@@ -41,7 +41,7 @@ class ParsedCache():
         self.load_participation_factors = load_participation_factors
 
         # Find and save the index of the first row of each sim type in timeseries_df
-        cur_sim = self.timeseries_df['Simulation'][0]
+        cur_sim = self.timeseries_df['Simulation'].iat[0]
         self._first_indices = {cur_sim:0}
         for i in range(1,len(self.timeseries_df)):
             if self.timeseries_df['Simulation'].iat[i] != cur_sim:


### PR DESCRIPTION

## Fixes # .
The RTS-GMLC parser references a particular DataFrame cell by row key where it should reference by row position. The test didn't catch this because the first row of the data frame has a key of 0 in the RTS-GMLC data we test against. That isn't guaranteed to the case in other data sets.

## Summary/Motivation:


## Changes proposed in this PR:
- Fix indexing

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
