### PR TITLE
Updating mutable penalty params

### DIFF
--- a/egret/common/lazy_ptdf_utils.py
+++ b/egret/common/lazy_ptdf_utils.py
@@ -697,7 +697,7 @@ def _add_contingency_violations(lazy_violations, flows, mb, md, solver, ptdf_opt
         contingencies_monitored.append((cn, i_b))
         if new_slacks:
             m = model
-            obj_coef = pyo.value(m.TimePeriodLengthHours*m.SystemContingencyLimitPenalty)
+            obj_coef = m.TimePeriodLengthHours*m.SystemContingencyLimitPenalty
 
             if persistent_solver:
                 m_model = m.model()

--- a/egret/model_library/unit_commitment/services.py
+++ b/egret/model_library/unit_commitment/services.py
@@ -275,23 +275,28 @@ def ancillary_services(model):
     default_reg_pen = value(model.LoadMismatchPenalty+model.ReserveShortfallPenalty)/2.
     ## set these penalties in relation to each other, from higher quality service to lower
     model.RegulationPenalty = Param(within=NonNegativeReals,
-                                    initialize=system.get('regulation_penalty_price', default_reg_pen))
+            initialize=system.get('regulation_penalty_price', default_reg_pen),
+            mutable=True)
 
     default_spin_pen = value(model.RegulationPenalty+model.ReserveShortfallPenalty)/2.
     model.SpinningReservePenalty = Param(within=NonNegativeReals, 
-                                         initialize=system.get('spinning_reserve_penalty_price', default_spin_pen))
+            initialize=system.get('spinning_reserve_penalty_price', default_spin_pen),
+            mutable=True)
 
     default_nspin_pen = value(model.SpinningReservePenalty+model.ReserveShortfallPenalty)/2.
     model.NonSpinningReservePenalty = Param(within=NonNegativeReals,
-                                            initialize=system.get('non_spinning_reserve_penalty_price', default_nspin_pen))
+            initialize=system.get('non_spinning_reserve_penalty_price', default_nspin_pen),
+            mutable=True)
 
     default_supp_pen = value(model.NonSpinningReservePenalty+model.ReserveShortfallPenalty)/2.
     model.SupplementalReservePenalty = Param(within=NonNegativeReals,
-                                             initialize=system.get('supplemental_reserve_penalty_price', default_supp_pen))
+            initialize=system.get('supplemental_reserve_penalty_price', default_supp_pen),
+            mutable=True)
 
     default_flex_pen = value(model.NonSpinningReservePenalty+model.SpinningReservePenalty)/2.
     model.FlexRampPenalty = Param(within=NonNegativeReals,
-                                  initialize=system.get('flexible_ramp_penalty_price', default_flex_pen))
+            initialize=system.get('flexible_ramp_penalty_price', default_flex_pen),
+            mutable=True)
 
     thermal_gen_attrs = md.attributes(element_type='generator', generator_type='thermal')
     


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Updates for objective function mutability, driven by https://github.com/grid-parity-exchange/Prescient/issues/110

## Changes proposed in this PR:
- Make reserve penalty Parameters mutable
- Fix bug in the lazy objective function, which wasn't respecting the mutability of `SystemContingencyLimitPenalty`

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
