### PR TITLE
Using python standard version names

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup, find_packages
 from distutils.core import Extension
 
 DISTNAME = 'gridx-egret'
-VERSION = '0.5.2-dev'
+VERSION = '0.5.2.dev0'
 PACKAGES = find_packages()
 EXTENSIONS = []
 DESCRIPTION = 'EGRET: Electrical Grid Research and Engineering Tools.'


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
This is what `setuptools` ends up calling this version anyways:
```
~/.local/lib/python3.7/site-packages/setuptools/dist.py:452: UserWarning: Normalizing '0.5.2-dev' to '0.5.2.dev0'
```
## Changes proposed in this PR:
- Change version from `0.5.2-dev` to `0.5.2.dev0`.
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
