### PR TITLE
more robust handling of voltage angle difference limits

### DIFF
--- a/egret/models/tests/test_acopf.py
+++ b/egret/models/tests/test_acopf.py
@@ -211,5 +211,31 @@ class TestPWCost(unittest.TestCase):
         self.assertAlmostEqual(pw_obj, 803.56080829371604, places=2)
 
 
+class TestDeltaThetaBounds(unittest.TestCase):
+    def test_0_delta_theta_bounds(self):
+        md = ModelData.read(os.path.join(current_dir, 'transmission_test_instances', 'test_instances', 'delta_theta_bounds_0.m'))
+        m, _ = create_psv_acopf_model(md)
+        self.assertAlmostEqual(m.s['1','2'].lb, -1.21)
+        self.assertAlmostEqual(m.s['1','2'].ub, 1.21)
+        self.assertAlmostEqual(m.c['1','2'].lb, -1.21)
+        self.assertAlmostEqual(m.c['1','2'].ub, 1.21)
+
+    def test_minus_10_to_10_delta_theta_bounds(self):
+        md = ModelData.read(os.path.join(current_dir, 'transmission_test_instances', 'test_instances', 'delta_theta_bounds_minus_10_to_10.m'))
+        m, _ = create_psv_acopf_model(md)
+        self.assertAlmostEqual(m.s['1','2'].lb, 1.21 * math.sin(math.radians(-10)))
+        self.assertAlmostEqual(m.s['1','2'].ub, 1.21 * math.sin(math.radians(10)))
+        self.assertAlmostEqual(m.c['1','2'].lb, 0.81 * math.cos(math.radians(-10)))
+        self.assertAlmostEqual(m.c['1','2'].ub, 1.21)
+
+    def test_10_to_20_delta_theta_bounds(self):
+        md = ModelData.read(os.path.join(current_dir, 'transmission_test_instances', 'test_instances', 'delta_theta_bounds_10_to_20.m'))
+        m, _ = create_psv_acopf_model(md)
+        self.assertAlmostEqual(m.s['1','2'].lb, 0.81 * math.sin(math.radians(10)))
+        self.assertAlmostEqual(m.s['1','2'].ub, 1.21 * math.sin(math.radians(20)))
+        self.assertAlmostEqual(m.c['1','2'].ub, 1.21 * math.cos(math.radians(10)))
+        self.assertAlmostEqual(m.c['1','2'].lb, 0.81 * math.cos(math.radians(20)))
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/egret/models/tests/transmission_test_instances/test_instances/delta_theta_bounds_0.m
+++ b/egret/models/tests/transmission_test_instances/test_instances/delta_theta_bounds_0.m
@@ -1,0 +1,20 @@
+function mpc = delta_theta_bounds_0
+mpc.version = '2';
+mpc.baseMVA = 100.0;
+
+mpc.bus = [
+	1    3    0    0    0    0    1    1    0    240    1    1.1    0.9;
+	2    1    100  100  0    0    1    1    0    240    1    1.1    0.9;
+];
+
+mpc.gen = [
+	1 100  100  300 -300 1    100    1    300  -300;
+];
+
+mpc.gencost = [
+	   2    0    0    3    1    1    1;
+];
+
+mpc.branch = [
+	   1    2    0.1    0.1    0.1    500  500  500  0    0    1    0    0;
+];

--- a/egret/models/tests/transmission_test_instances/test_instances/delta_theta_bounds_10_to_20.m
+++ b/egret/models/tests/transmission_test_instances/test_instances/delta_theta_bounds_10_to_20.m
@@ -1,0 +1,20 @@
+function mpc = delta_theta_bounds_10_to_20
+mpc.version = '2';
+mpc.baseMVA = 100.0;
+
+mpc.bus = [
+	1    3    0    0    0    0    1    1    0    240    1    1.1    0.9;
+	2    1    100  100  0    0    1    1    0    240    1    1.1    0.9;
+];
+
+mpc.gen = [
+	1 100  100  300 -300 1    100    1    300  -300;
+];
+
+mpc.gencost = [
+	   2    0    0    3    1    1    1;
+];
+
+mpc.branch = [
+	   1    2    0.1    0.1    0.1    500  500  500  0    0    1    10   20;
+];

--- a/egret/models/tests/transmission_test_instances/test_instances/delta_theta_bounds_minus_10_to_10.m
+++ b/egret/models/tests/transmission_test_instances/test_instances/delta_theta_bounds_minus_10_to_10.m
@@ -1,0 +1,20 @@
+function mpc = delta_theta_bounds_minus_10_to_10
+mpc.version = '2';
+mpc.baseMVA = 100.0;
+
+mpc.bus = [
+	1    3    0    0    0    0    1    1    0    240    1    1.1    0.9;
+	2    1    100  100  0    0    1    1    0    240    1    1.1    0.9;
+];
+
+mpc.gen = [
+	1 100  100  300 -300 1    100    1    300  -300;
+];
+
+mpc.gencost = [
+	   2    0    0    3    1    1    1;
+];
+
+mpc.branch = [
+	   1    2    0.1    0.1    0.1    500  500  500  0    0    1    -10  10;
+];


### PR DESCRIPTION
## Summary/Motivation:
The computation of bounds for the auxiliary variables `c = v_f * v_t * cos(dt)` and `s = vf * vt * sin(dt)` had bugs. This PR uses interval arithmetic to improve the robustness of these computations and adds tests.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
