### PR TITLE
Enabling interactive graphics

### DIFF
--- a/egret/viz/generate_graphs.py
+++ b/egret/viz/generate_graphs.py
@@ -1,12 +1,17 @@
 import os
+import sys
 from collections import namedtuple, defaultdict
 import datetime
 import textwrap
 
 import matplotlib as mpl
-## catch when we're running linux without X
-if os.name == 'posix' and 'DISPLAY' not in os.environ:
-    mpl.use('Agg')
+if not hasattr(sys, 'ps1'):
+    # Not in interactive mode, so use the AGG backend for
+    # systems without GUIs (which probably will not be run
+    # in interactive mode). See the discussion on
+    # https://stackoverflow.com/questions/2356399/tell-if-python-is-in-interactive-mode
+    # and the definition https://docs.python.org/3/library/sys.html#sys.ps1
+    mpl.use('AGG')
 
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Only set `'AGG'` matplotlib backend if Python isn't launched in interactive mode. As-is, sometimes you cannot generate graphs in jupyter notebooks if Egret's graph generation code has been imported.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
