### PR TITLE
Updating Tests

### DIFF
--- a/egret/models/tests/test_relaxations.py
+++ b/egret/models/tests/test_relaxations.py
@@ -82,7 +82,7 @@ class TestRelaxations(unittest.TestCase):
         rel, scaled_md = create_soc_relaxation(md, use_linear_relaxation=False)
 
         opt = SolverFactory('ipopt')
-        opt.options['linear_solver'] = 'mumps'
+        #opt.options['linear_solver'] = 'mumps'
 
         res = opt.solve(nlp, tee=False)
         self.assertTrue(res.solver.termination_condition == TerminationCondition.optimal)
@@ -112,7 +112,7 @@ class TestRelaxations(unittest.TestCase):
             b.rebuild(build_nonlinear_constraint=True)
 
         opt = SolverFactory('ipopt')
-        opt.options['linear_solver'] = 'mumps'
+        #opt.options['linear_solver'] = 'mumps'
 
         res = opt.solve(nlp, tee=False)
         self.assertTrue(res.solver.termination_condition == TerminationCondition.optimal)
@@ -130,7 +130,7 @@ class TestRelaxations(unittest.TestCase):
             b.rebuild(build_nonlinear_constraint=True)
 
         opt = SolverFactory('ipopt')
-        opt.options['linear_solver'] = 'mumps'
+        #opt.options['linear_solver'] = 'mumps'
 
         res = opt.solve(nlp, tee=False)
         self.assertTrue(res.solver.termination_condition == TerminationCondition.optimal)
@@ -148,7 +148,7 @@ class TestRelaxations(unittest.TestCase):
             b.rebuild(build_nonlinear_constraint=True)
 
         opt = SolverFactory('ipopt')
-        opt.options['linear_solver'] = 'mumps'
+        #opt.options['linear_solver'] = 'mumps'
 
         res = opt.solve(nlp, tee=False)
         self.assertTrue(res.solver.termination_condition == TerminationCondition.optimal)
@@ -166,7 +166,7 @@ class TestRelaxations(unittest.TestCase):
             b.rebuild(build_nonlinear_constraint=True)
 
         opt = SolverFactory('ipopt')
-        opt.options['linear_solver'] = 'mumps'
+        #opt.options['linear_solver'] = 'mumps'
 
         res = opt.solve(nlp, tee=False)
         self.assertTrue(res.solver.termination_condition == TerminationCondition.optimal)


### PR DESCRIPTION
## Summary/Motivation:
In the past, we had specified the linear solver Ipopt should use in order for local tests to behave the same as tests on GHA. I think this may be causing problems on the Windows builds.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
