### PR TITLE
option to keep variables for out of service elements

### DIFF
--- a/.github/workflows/egret.yml
+++ b/.github/workflows/egret.yml
@@ -95,6 +95,7 @@ jobs:
                     $URL/idaes-lib-windows-64.tar.gz > $IPOPT_TAR
                 fi
                 cd $IPOPT_DIR
+                ls -l $IPOPT_TAR
                 tar -xvi < $IPOPT_TAR
                 echo ""
                 echo "$IPOPT_DIR"

--- a/.github/workflows/egret.yml
+++ b/.github/workflows/egret.yml
@@ -95,7 +95,7 @@ jobs:
                     $URL/idaes-lib-windows-64.tar.gz > $IPOPT_TAR
                 fi
                 cd $IPOPT_DIR
-                tar -xzi < $IPOPT_TAR
+                tar -xvi < $IPOPT_TAR
                 echo ""
                 echo "$IPOPT_DIR"
                 ls -l $IPOPT_DIR

--- a/.github/workflows/egret.yml
+++ b/.github/workflows/egret.yml
@@ -86,17 +86,16 @@ jobs:
                   #  - ipopt needs: libopenblas-dev gfortran liblapack-dev
                   sudo apt-get install libopenblas-dev libgfortran4 libgomp1 gfortran liblapack-dev
                   curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-ubuntu1804-64.tar.gz \
+                    -L $URL/idaes-solvers-ubuntu1804-x86_64.tar.gz \
                     > $IPOPT_TAR
                 else
                   # windows
                    curl --max-time 150 --retry 8 \
-                    -L $URL/idaes-solvers-windows-64.tar.gz \
-                    $URL/idaes-lib-windows-64.tar.gz > $IPOPT_TAR
+                    -L $URL/idaes-solvers-windows-x86_64.tar.gz \
+                    $URL/idaes-lib-windows-x86_64.tar.gz > $IPOPT_TAR
                 fi
                 cd $IPOPT_DIR
-                ls -l $IPOPT_TAR
-                tar -xvi < $IPOPT_TAR
+                tar -xzi < $IPOPT_TAR
                 echo ""
                 echo "$IPOPT_DIR"
                 ls -l $IPOPT_DIR

--- a/.github/workflows/egret.yml
+++ b/.github/workflows/egret.yml
@@ -29,14 +29,14 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.7, 3.8, 3.9]
-                pyomo-version: [6.1.2]
+                pyomo-version: [6.4.0]
                 include:
                     - os: macos-latest
                       python-version: 3.7
-                      pyomo-version: 6.1.2
+                      pyomo-version: 6.4.0
                     - os: windows-latest
                       python-version: 3.7
-                      pyomo-version: 6.1.2
+                      pyomo-version: 6.4.0
                     - os: ubuntu-latest
                       python-version: 3.7
                       pyomo-version: main

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ EGRET is available under the BSD License (see [LICENSE.txt](https://github.com/g
 ### Requirements
 
 * Python 3.7 or later
-* Pyomo version 6.1.2 or later
+* Pyomo version 6.4.0 or later
 * pytest
 * Optimization solvers for Pyomo - specific requirements depends on the models being solved. EGRET is tested with Gurobi or CPLEX for MIP-based problems (e.g., unit commitment) and Ipopt (with HSL linear solvers) for NLP problems.
 

--- a/egret/model_library/transmission/tx_utils.py
+++ b/egret/model_library/transmission/tx_utils.py
@@ -17,9 +17,38 @@ import math
 from math import radians
 import logging
 import copy
+from collections import OrderedDict
+from egret.data.data_utils import map_items, zip_items
 
 
 logger = logging.getLogger(__name__)
+
+
+def get_unique_bus_pairs(md):
+    branch_attrs = md.attributes(element_type='branch')
+    bus_pairs = zip_items(branch_attrs['from_bus'], branch_attrs['to_bus'])
+    unique_bus_pairs = list(OrderedDict((val, None) for idx, val in bus_pairs.items()))
+    return unique_bus_pairs
+
+
+def _get_out_of_service_gens(md):
+    out_of_service_gens = list()
+    for gen_name, gen_dict in md.elements(element_type='generator'):
+        if not gen_dict['in_service']:
+            out_of_service_gens.append(gen_name)
+            gen_dict['in_service'] = True
+
+    return out_of_service_gens
+
+
+def _get_out_of_service_branches(md):
+    out_of_service_branches = list()
+    for branch_name, branch_dict in md.elements(element_type='branch'):
+        if not branch_dict['in_service']:
+            out_of_service_branches.append(branch_name)
+            branch_dict['in_service'] = True
+
+    return out_of_service_branches
 
 
 def dicts_of_vr_vj(buses):

--- a/egret/models/ac_relaxations.py
+++ b/egret/models/ac_relaxations.py
@@ -217,8 +217,10 @@ class SOCEdgeCutsData(BaseRelaxationData):
 def create_soc_relaxation(model_data,
                           use_linear_relaxation=True,
                           include_feasibility_slack=False,
-                          use_fbbt=True):
-    model, md = _create_base_power_ac_model(model_data, include_feasibility_slack=include_feasibility_slack)
+                          use_fbbt=True,
+                          keep_vars_for_out_of_service_elements=False):
+    model, md = _create_base_power_ac_model(model_data, include_feasibility_slack=include_feasibility_slack,
+                                            keep_vars_for_out_of_service_elements=keep_vars_for_out_of_service_elements)
     if use_linear_relaxation:
         _relaxation_helper(model=model,
                            md=md,
@@ -238,8 +240,10 @@ def create_atan_relaxation(model_data,
                            use_linear_relaxation=True,
                            include_feasibility_slack=False,
                            use_soc_edge_cuts=False,
-                           use_fbbt=True):
-    model, md = create_atan_acopf_model(model_data=model_data, include_feasibility_slack=include_feasibility_slack)
+                           use_fbbt=True,
+                           keep_vars_for_out_of_service_elements=False):
+    model, md = create_atan_acopf_model(model_data=model_data, include_feasibility_slack=include_feasibility_slack,
+                                        keep_vars_for_out_of_service_elements=keep_vars_for_out_of_service_elements)
     del model.ineq_soc
     del model._con_ineq_soc
     if use_soc_edge_cuts:
@@ -268,8 +272,10 @@ def create_polar_acopf_relaxation(model_data,
                                   include_soc=True,
                                   use_linear_relaxation=True,
                                   include_feasibility_slack=False,
-                                  use_fbbt=True):
-    model, md = create_psv_acopf_model(model_data, include_feasibility_slack=include_feasibility_slack)
+                                  use_fbbt=True,
+                                  keep_vars_for_out_of_service_elements=False):
+    model, md = create_psv_acopf_model(model_data, include_feasibility_slack=include_feasibility_slack,
+                                       keep_vars_for_out_of_service_elements=keep_vars_for_out_of_service_elements)
     _relaxation_helper(model=model,
                        md=md,
                        include_soc=include_soc,
@@ -282,8 +288,10 @@ def create_rectangular_acopf_relaxation(model_data,
                                         include_soc=True,
                                         use_linear_relaxation=True,
                                         include_feasibility_slack=False,
-                                        use_fbbt=True):
-    model, md = create_rsv_acopf_model(model_data, include_feasibility_slack=include_feasibility_slack)
+                                        use_fbbt=True,
+                                        keep_vars_for_out_of_service_elements=False):
+    model, md = create_rsv_acopf_model(model_data, include_feasibility_slack=include_feasibility_slack,
+                                       keep_vars_for_out_of_service_elements=keep_vars_for_out_of_service_elements)
     _relaxation_helper(model=model,
                        md=md,
                        include_soc=include_soc,

--- a/egret/models/dcopf.py
+++ b/egret/models/dcopf.py
@@ -52,8 +52,8 @@ def _include_feasibility_slack(model, bus_names, bus_p_loads, gens_by_bus, gen_a
 def create_btheta_dcopf_model(model_data, include_angle_diff_limits=False, include_feasibility_slack=False, pw_cost_model='delta',
                               keep_vars_for_out_of_service_elements=False):
     if keep_vars_for_out_of_service_elements:
-        out_of_service_gens = tx_utils.get_out_of_service_gens(model_data)
-        out_of_service_branches = tx_utils.get_out_of_service_branches(model_data)
+        out_of_service_gens = tx_utils._get_out_of_service_gens(model_data)
+        out_of_service_branches = tx_utils._get_out_of_service_branches(model_data)
     else:
         out_of_service_gens = list()
         out_of_service_branches = list()

--- a/egret/models/tests/test_acopf.py
+++ b/egret/models/tests/test_acopf.py
@@ -14,6 +14,7 @@ import os
 import math
 import unittest
 from pyomo.opt import SolverFactory, TerminationCondition
+import pyomo.environ as pe
 from egret.models.acopf import *
 from egret.data.model_data import ModelData
 from parameterized import parameterized
@@ -84,6 +85,29 @@ class TestPSVACOPF(unittest.TestCase):
         self.assertTrue(comparison)
         _test_p_and_v(self, p_and_v_soln_case, md)
 
+    def test_keep_vars(self):
+        fname = os.path.join(current_dir, 'transmission_test_instances/pglib-opf-master/pglib_opf_case5_pjm.m')
+        md = ModelData.read(fname)
+        md.data["elements"]["generator"]["1"]["in_service"] = False
+        md.data["elements"]["branch"]["2"]["in_service"] = False
+
+        m1, _ = create_psv_acopf_model(md, keep_vars_for_out_of_service_elements=False)
+        m2, _ = create_psv_acopf_model(md, keep_vars_for_out_of_service_elements=True)
+
+        opt = SolverFactory('ipopt')
+        res1 = opt.solve(m1)
+        res2 = opt.solve(m2)
+
+        self.assertEqual(res1.solver.termination_condition, TerminationCondition.optimal)
+        self.assertEqual(res2.solver.termination_condition, TerminationCondition.optimal)
+
+        obj1 = pe.value(m1.obj)
+        obj2 = pe.value(m2.obj)
+
+        self.assertAlmostEqual(obj1, obj2)
+        self.assertTrue(m2.pg["1"].fixed)
+
+        
 class TestArctanACOPF(unittest.TestCase):
     show_output = True
 
@@ -105,6 +129,28 @@ class TestArctanACOPF(unittest.TestCase):
 
         self.assertTrue(res.solver.termination_condition == TerminationCondition.optimal)
         self.assertAlmostEqual(pe.value(model.obj)/md_soln.data['system']['total_cost'], 1, 4)
+
+    def test_keep_vars(self):
+        fname = os.path.join(current_dir, 'transmission_test_instances/pglib-opf-master/pglib_opf_case5_pjm.m')
+        md = ModelData.read(fname)
+        md.data["elements"]["generator"]["1"]["in_service"] = False
+        md.data["elements"]["branch"]["2"]["in_service"] = False
+
+        m1, _ = create_atan_acopf_model(md, keep_vars_for_out_of_service_elements=False)
+        m2, _ = create_atan_acopf_model(md, keep_vars_for_out_of_service_elements=True)
+
+        opt = SolverFactory('ipopt')
+        res1 = opt.solve(m1)
+        res2 = opt.solve(m2)
+
+        self.assertEqual(res1.solver.termination_condition, TerminationCondition.optimal)
+        self.assertEqual(res2.solver.termination_condition, TerminationCondition.optimal)
+
+        obj1 = pe.value(m1.obj)
+        obj2 = pe.value(m2.obj)
+
+        self.assertAlmostEqual(obj1, obj2)
+        self.assertTrue(m2.pg["1"].fixed)
 
 class TestRSVACOPF(unittest.TestCase):
     show_output = True
@@ -134,6 +180,29 @@ class TestRSVACOPF(unittest.TestCase):
         self.assertTrue(comparison)
         _test_p_and_v(self, p_and_v_soln_case, md)
 
+    def test_keep_vars(self):
+        fname = os.path.join(current_dir, 'transmission_test_instances/pglib-opf-master/pglib_opf_case5_pjm.m')
+        md = ModelData.read(fname)
+        md.data["elements"]["generator"]["1"]["in_service"] = False
+        md.data["elements"]["branch"]["2"]["in_service"] = False
+
+        m1, _ = create_rsv_acopf_model(md, keep_vars_for_out_of_service_elements=False)
+        m2, _ = create_rsv_acopf_model(md, keep_vars_for_out_of_service_elements=True)
+
+        opt = SolverFactory('ipopt')
+        res1 = opt.solve(m1)
+        res2 = opt.solve(m2)
+
+        self.assertEqual(res1.solver.termination_condition, TerminationCondition.optimal)
+        self.assertEqual(res2.solver.termination_condition, TerminationCondition.optimal)
+
+        obj1 = pe.value(m1.obj)
+        obj2 = pe.value(m2.obj)
+
+        self.assertAlmostEqual(obj1, obj2)
+        self.assertTrue(m2.pg["1"].fixed)
+
+        
 class TestRIVACOPF(unittest.TestCase):
     show_output = True
 

--- a/egret/models/tests/test_dcopf.py
+++ b/egret/models/tests/test_dcopf.py
@@ -143,6 +143,44 @@ class TestPWCostBTheta(unittest.TestCase):
         pw_obj = pe.value(m_pw.obj.expr)
         self.assertAlmostEqual(pw_obj, 767.74029197558707, places=2)
 
+    def test_pw_cost_with_out_of_service_gens(self):
+        md = ModelData.read(os.path.join(current_dir, 'transmission_test_instances', 'pglib-opf-master', 'pglib_opf_case30_as.m'))
+        poly_cost_to_pw_cost(md, num_points=3)
+        md.data["elements"]["generator"]["2"]["in_service"] = False
+        m1, _ = create_btheta_dcopf_model(md, keep_vars_for_out_of_service_elements=False)
+        m2, _ = create_btheta_dcopf_model(md, keep_vars_for_out_of_service_elements=True)
+
+        opt = pe.SolverFactory('ipopt')
+        res1 = opt.solve(m1)
+        res2 = opt.solve(m2)
+
+        self.assertEqual(res1.solver.termination_condition, TerminationCondition.optimal)
+        self.assertEqual(res2.solver.termination_condition, TerminationCondition.optimal)
+
+        obj1 = pe.value(m1.obj)
+        obj2 = pe.value(m2.obj)
+
+        self.assertAlmostEqual(obj1, obj2)
+
+    def test_pw_cost_with_out_of_service_gens_epi(self):
+        md = ModelData.read(os.path.join(current_dir, 'transmission_test_instances', 'pglib-opf-master', 'pglib_opf_case30_as.m'))
+        poly_cost_to_pw_cost(md, num_points=3)
+        md.data["elements"]["generator"]["2"]["in_service"] = False
+        m1, _ = create_btheta_dcopf_model(md, keep_vars_for_out_of_service_elements=False, pw_cost_model='epi')
+        m2, _ = create_btheta_dcopf_model(md, keep_vars_for_out_of_service_elements=True, pw_cost_model='epi')
+
+        opt = pe.SolverFactory('ipopt')
+        res1 = opt.solve(m1)
+        res2 = opt.solve(m2)
+
+        self.assertEqual(res1.solver.termination_condition, TerminationCondition.optimal)
+        self.assertEqual(res2.solver.termination_condition, TerminationCondition.optimal)
+
+        obj1 = pe.value(m1.obj)
+        obj2 = pe.value(m2.obj)
+
+        self.assertAlmostEqual(obj1, obj2)
+
 
 class TestPWCostPTDF(unittest.TestCase):
     @classmethod

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools_kwargs = {
     'zip_safe': False,
     'scripts': [],
     'include_package_data': True,
-    'install_requires': ['pyomo>=6.1.2', 'numpy', 'pytest', 'pandas',
+    'install_requires': ['pyomo>=6.4', 'numpy', 'pytest', 'pandas',
                          'matplotlib', 'seaborn', 'scipy', 'networkx',
                          'coramin==0.1.1'],
     'python_requires' : '>=3.7, <4',


### PR DESCRIPTION
## Summary/Motivation:
This PR adds an option to the ACOPF and DCOPF models to construct variables corresponding to out-of-service generators and transmission lines.


### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
