### PR TITLE
Include DC branches when reading GMLC-formatted csv files

### DIFF
--- a/egret/parsers/rts_gmlc/parser.py
+++ b/egret/parsers/rts_gmlc/parser.py
@@ -479,25 +479,20 @@ def _read_branches(base_dir:str, elements:dict, bus_id_to_name:dict) -> None:
     branch_df = None
 
     # add the DC branches
-    # TODO: see issue #229
-    #if os.path.exists(os.path.join(base_dir,'dc_branch.csv')):
-    #    elements["dc_branch"] = {}
-    #    branch_df = pd.read_csv(os.path.join(base_dir,'dc_branch.csv'))
-    #    for idx,row in branch_df.iterrows():
-
-    #        # TODO: The fields below don't match what Egrets expects or supports for DC branches.
-    #        #       The code below is just a placeholder.
-    #        branch_dict = {
-    #            "from_bus": bus_id_to_name[str(row['From Bus'])], 
-    #            "to_bus": bus_id_to_name[str(row['To Bus'])],
-    #            "in_service": True,
-    #            "branch_type": "dc",
-    #            "resistance": float(row['R Line'])
-    #        }
-
-    #        name = str(row['UID'])
-    #        elements["dc_branch"][name] = branch_dict
-    #    branch_df = None
+    if os.path.exists(os.path.join(base_dir,'dc_branch.csv')):
+        elements["dc_branch"] = {}
+        branch_df = pd.read_csv(os.path.join(base_dir,'dc_branch.csv'))
+        for idx,row in branch_df.iterrows():
+            branch_dict = {
+                "from_bus": bus_id_to_name[str(row['From Bus'])], 
+                "to_bus": bus_id_to_name[str(row['To Bus'])],
+                "rating_short_term": float(row['MW Load']),
+                "rating_long_term": float(row['MW Load']),
+                "rating_emergency": float(row['MW Load'])
+            }
+            name = str(row['UID'])
+            elements["dc_branch"][name] = branch_dict
+        branch_df = None
 
 def _read_generators(base_dir:str, elements:dict, bus_id_to_name:dict) -> None:
     from math import isnan


### PR DESCRIPTION
## Summary/Motivation:

A project that uses Egret has requested this feature

## Changes proposed in this PR:
- When parsing files in GMLC format, read DC branch information.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
