### PR TITLE
Ensure area names are read as strings in RTS-GMLC, even if numeric

### DIFF
--- a/egret/parsers/rts_gmlc/parser.py
+++ b/egret/parsers/rts_gmlc/parser.py
@@ -154,7 +154,7 @@ def parse_to_cache(rts_gmlc_dir:str,
 def _read_metadata(base_dir:str) -> pd.DataFrame:
     metadata_path = os.path.join(base_dir, "simulation_objects.csv")
     if not os.path.exists(metadata_path):
-        raise ValueError(f'RTS-GMLC directory "{base_dir}" does not contain expected CSV files.')
+        raise ValueError(f'RTS-GMLC directory "{rts_gmlc_dir}" does not contain expected CSV files.')
 
     # Read metadata about the data
     metadata_df = pd.read_csv(metadata_path, index_col=0)
@@ -777,7 +777,8 @@ def _read_timeseries_data(model_data:dict, rts_gmlc_dir:str,
     # All timeseries data that has already been read (map[filename] -> DataFrame)
     timeseries_file_map = {}
 
-    timeseries_pointer_df = pd.read_csv(os.path.join(rts_gmlc_dir, "timeseries_pointers.csv"), header=0)
+    timeseries_pointer_df = pd.read_csv(os.path.join(rts_gmlc_dir, "timeseries_pointers.csv"), 
+                                        header=0, dtype={'Object':str})
 
     elements = model_data['elements']
     params_of_interest = {
@@ -808,7 +809,7 @@ def _read_timeseries_data(model_data:dict, rts_gmlc_dir:str,
         is_reserve = (row['Category'] == 'Reserve')
         if is_reserve:
             # Skip unrecognized reserve names
-            name = str(row['Object'])
+            name = row['Object']
             if not is_valid_reserve_name(name, model_data):
                 continue
 


### PR DESCRIPTION
## Fixes # .
When parsing RTS-GMLC csv files, if area names were numeric (such as an area named "1"), then some places in the RTS-GMLC parser read the area names as strings and other places read the names as numbers. This caused time series data for areas to not be associated with the correct area.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
