### PR TITLE
Make egret compatible with pandas 1.5

### DIFF
--- a/.github/workflows/prescient.yml
+++ b/.github/workflows/prescient.yml
@@ -23,7 +23,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.7]
+                python-version: [3.9]
                 pyomo-version: [6.4.0]
         steps:
           - uses: actions/checkout@v2
@@ -38,15 +38,7 @@ jobs:
               conda list
           - name: Install CBC
             run: |
-              if [ ${{ matrix.os }} = windows-latest ]
-              then
-                # download CBC binary, copy to place already in PATH
-                curl -O https://ampl.com/dl/open/cbc/cbc-win64.zip
-                unzip cbc-win64.zip
-                cp cbc.exe $CONDA_PREFIX
-              else
-                conda install -c conda-forge coincbc
-              fi
+              conda install -c conda-forge coincbc
               # test cbc executable
               cbc -quit
           - name: Install Pyomo

--- a/egret/parsers/rts_gmlc/parser.py
+++ b/egret/parsers/rts_gmlc/parser.py
@@ -787,9 +787,8 @@ def _read_timeseries_data(model_data:dict, rts_gmlc_dir:str,
         'Area':      {'MW Load'}
         }
 
-    # Add a column to timeseries DF to reference the parsed data 
-    # instead of the file name
-    timeseries_pointer_df['Series'] = None
+    # Create an array where we can gather parsed timeseries data
+    series_data = [None]*timeseries_pointer_df.shape[0]
 
     # Store the timeseries data in the timeseries DF
     for idx,row in timeseries_pointer_df.iterrows():
@@ -823,7 +822,10 @@ def _read_timeseries_data(model_data:dict, rts_gmlc_dir:str,
             timeseries_file_map[fname] = data
 
         # Save a reference to the relevant data as a Series
-        timeseries_pointer_df.at[idx,'Series'] = timeseries_file_map[fname][row['Object']]
+        series_data[idx]= timeseries_file_map[fname][row['Object']]
+
+    # Add the 'Series' column
+    timeseries_pointer_df = timeseries_pointer_df.assign(Series=series_data)
 
     # Remove columns that we don't want to preserve
     keepers= {'Simulation', 'Category', 'Object', 'Parameter', 'Series'}

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools_kwargs = {
     'zip_safe': False,
     'scripts': [],
     'include_package_data': True,
-    'install_requires': ['pyomo>=6.4', 'numpy', 'pytest', 'pandas<1.5',
+    'install_requires': ['pyomo>=6.4', 'numpy', 'pytest', 'pandas',
                          'matplotlib', 'seaborn', 'scipy', 'networkx',
                          'coramin==0.1.1'],
     'python_requires' : '>=3.7, <4',


### PR DESCRIPTION
## Fixes #290.

## Summary/Motivation:
Fixes an error when using Pandas 1.5 or later. Pandas started converting Series objects into bare numpy arrays when assigning to a cell.

## Changes proposed in this PR:
- When reading RTS-GMLC csv data, use a different method to store Series objects in DataFrame cells.

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
