### PR TITLE
Fix date handling for 2D timeseries CSV layout

### DIFF
--- a/egret/parsers/rts_gmlc/parser.py
+++ b/egret/parsers/rts_gmlc/parser.py
@@ -298,11 +298,9 @@ def _read_2D_timeseries_file(file_name:str, minutes_per_period:int,
     period is included in the results.  Like a typical python range, the returned data includes 
     the start_time but does not include the end_time.
     """
-    _date_parser = lambda *columns: datetime(*map(int,columns[0:3]))
     df = pd.read_csv(file_name, 
                      header=0, 
-                     parse_dates=[[0, 1, 2]],
-                     date_parser=_date_parser,
+                     parse_dates=[['Year', 'Month', 'Day']],
                      index_col=0)
     df.sort_index(inplace=True)
 


### PR DESCRIPTION
## Fixes # .
Fixes reading dates from the 2D version of timeseries files (an example is at https://github.com/GridMod/RTS-GMLC/blob/master/RTS_Data/timeseries_data_files/Reserves/DAY_AHEAD_regional_Flex_Down.csv). Previous pull request only handled the columnar timeseries CSV format.

## Summary/Motivation:
Keep up with changes in pandas 2.0.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://github.com/grid-parity-exchange/Egret/blob/main/CONTRIBUTING.md) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
